### PR TITLE
Developer, Deploy with Brownie: YAML rendering error

### DIFF
--- a/content/docs/developer/deploy-brownie/_index.md
+++ b/content/docs/developer/deploy-brownie/_index.md
@@ -1,4 +1,4 @@
-n---
+---
 title: "Deploy smart contracts to an Autonity network with Brownie"
 linkTitle: "Deploy smart contracts with Brownie"
 weight: 170


### PR DESCRIPTION
Remove leading 'n' from YAML header, causing header rendering to fail.