### PR TITLE
fix GHCR and other Github links

### DIFF
--- a/content/docs/networks/testnet-bakerloo/_index.md
+++ b/content/docs/networks/testnet-bakerloo/_index.md
@@ -57,9 +57,9 @@ The network bootnode addresses are:
 
 ## Release
 
-- The current iteration of the Bakerloo network is built using this Autonity Release: [v0.9.0](https://github.com/autonity/autonity/releases/tag/v0.9.0)
+- The current iteration of the Bakerloo network is built using this Autonity Release: [v0.10.1](https://github.com/autonity/autonity/releases/tag/v0.10.1)
 
-- The nodes are running this docker image release: `ghcr.io/autonity/autonity/autonity:latest`
+- The nodes are running this docker image release: `ghcr.io/autonity/autonity:latest`
 
 ## Faucet
 

--- a/content/docs/networks/testnet-piccadilly/_index.md
+++ b/content/docs/networks/testnet-piccadilly/_index.md
@@ -58,9 +58,9 @@ The network bootnode addresses are:
 
 ## Release
 
-- The current iteration of the Piccadilly network is built using this Autonity Release: [v0.9.0](https://github.com/autonity/autonity/releases/tag/v0.9.0)
+- The current iteration of the Piccadilly network is built using this Autonity Release: [v0.10.1](https://github.com/autonity/autonity/releases/tag/v0.10.1)
 
-- The nodes are running this docker image release: `ghcr.io/autonity/autonity/autonity:latest`
+- The nodes are running this docker image release: `ghcr.io/autonity/autonity:latest`
 
 ## Faucet
 

--- a/content/docs/node-operators/install-aut/_index.md
+++ b/content/docs/node-operators/install-aut/_index.md
@@ -112,34 +112,9 @@ sudo systemctl restart docker
 ```
 {{< /alert >}}
 
-1. Verify the authenticity of the Autonity Docker images against the official [image digests](https://github.com/autonity/autonity/pkgs/container/autonity%2Fautonity):
-
+1. Pull the Autonity Go Client image from the Github Container Registry:
     ```bash
-    docker images --digests ghcr.io/autonity/autonity/autonity
-    REPOSITORY                               TAG       DIGEST                                                                    IMAGE ID       CREATED        SIZE
-    ghcr.io/autonity/autonity/autonity   latest    sha256:f374ac6575051037b03992854f1fb794b8b81eec3e7934849970ed192b08848c   a91c690c2bd0   5 months ago   51.6MB
-    ```
-
-    <!-- Required once the repo is public?? -->
-
-1. Create a GitHub personal access token to pull the Autonity Go Client Docker image from GitHub Container Registry. See [Login Credentials to GitHub Container Registry](/developer/#login-credentials-to-github-container-registry)
-
-1. Login to the Container Registry service, where:
-
-    - `<PAT_TOKEN>` is your GitHub PAT token
-    - `<GH_USERNAME>` is your GitHub username
-    - `password.txt` is your Docker login password
-
-	```bash
-	export GHCR_PAT="<PAT_TOKEN>"
-	export GH_USER="<GITHUB_USERNAME>"
-	echo $GHCR_PAT | docker login https://ghcr.io --username $GH_USER --password-stdin
-	```
-
-1. Pull the Autonity Docker image:
-
-    ```bash
-    docker pull ghcr.io/autonity/autonity/autonity:latest
+    docker pull ghcr.io/autonity/autonity:latest
     ```
 
    (where `latest` can be replaced with another version)
@@ -147,6 +122,14 @@ sudo systemctl restart docker
    {{< alert title="Note" >}}
    For more information on using and pulling Docker images from GHCR, see GitHub docs [Working with the container registry](https://docs.github.com/en/packages/working-with-a-github-packages-registry/working-with-the-container-registry).
    {{< /alert >}}
+
+1. Verify the authenticity of the Autonity Docker images against the official [image digests](https://github.com/autonity/autonity/pkgs/container/autonity/versions):
+
+    ```bash
+    docker images --digests ghcr.io/autonity/autonity
+    REPOSITORY                               TAG       DIGEST                                                                    IMAGE ID       CREATED        SIZE
+    ghcr.io/autonity/autonity                latest    sha256:0eb561ce19ed3617038b022db89586f40abb9580cb0c4cd5f28a7ce74728a3d4   3375da450343   3 weeks ago    51.7MB
+    ```
 
 {{% pageinfo %}}
 You can now [configure and launch Autonity](/node-operators/run-aut/#run-docker).
@@ -209,19 +192,17 @@ GOROOT=/usr/local/go
 If using Docker, the setup of the image can be verified with:
 
 ```bash
-$ docker run --rm ghcr.io/autonity/autonity/autonity:latest version
+$ docker run --rm ghcr.io/autonity/autonity:latest version
 ```
 ```bash
 Autonity
-Version: 0.10.0
-Git Commit: 1183a1130f192c70cab78831c76aed16f5715eca
-Git Commit Date: 20230118
+Version: 0.10.1
 Architecture: amd64
 Protocol Versions: [66]
-Go Version: go1.18.1
+Go Version: go1.17.10
 Operating System: linux
 GOPATH=
-GOROOT=go
+GOROOT=/usr/local/go
 ```
 
 {{< alert title="Note" >}}

--- a/content/docs/node-operators/install-aut/_index.md
+++ b/content/docs/node-operators/install-aut/_index.md
@@ -176,7 +176,7 @@ You should now be able to execute the `autonity` command.  Verify your installat
 ```bash
 $ ./autonity version
 ```
-```bash
+```
 Autonity
 Version: 0.10.1
 Architecture: amd64
@@ -194,7 +194,7 @@ If using Docker, the setup of the image can be verified with:
 ```bash
 $ docker run --rm ghcr.io/autonity/autonity:latest version
 ```
-```bash
+```
 Autonity
 Version: 0.10.1
 Architecture: amd64

--- a/content/docs/node-operators/run-aut/_index.md
+++ b/content/docs/node-operators/run-aut/_index.md
@@ -73,7 +73,7 @@ Autonity will download the blockchain in "snap" syncmode by default.  Once fully
        --publish 6060:6060 \
        --name autonity \
        --rm \
-       ghcr.io/autonity/autonity/autonity:latest \
+       ghcr.io/autonity/autonity:latest \
            --datadir ./autonity-chaindata  \
            --piccadilly \
            --http  \


### PR DESCRIPTION
* fixes GHCR address (see #19 and the first point raised in https://github.com/autonity/docs.autonity.org/issues/37)
* removes PAT configuration for access to GHCR since the repo is public
* updates to correct release number on Bakerloo and Piccadilly pages
