### PR TITLE
fix URL for autrc

### DIFF
--- a/content/docs/account-holders/setup-autcli/_index.md
+++ b/content/docs/account-holders/setup-autcli/_index.md
@@ -32,7 +32,7 @@ As detailed in the [`aut` CLI repository](https://github.com/autonity/autcli), s
 
 ```
 [aut]
-rpc_endpoint=https://NETWORK_NAME.autonity.org
+rpc_endpoint=https://rpc1.<NETWORK_NAME>.autonity.org
 ```
 
 See the [list of available networks](/networks/) to determine the correct endpoint to use.


### PR DESCRIPTION
See 3rd point raised in https://github.com/autonity/docs.autonity.org/issues/37

Adds `rpc1` to the URL string for configuring the RPC endpoint in `.autrc`.