### PR TITLE
Fix stray quotation mark and numbering of steps

### DIFF
--- a/content/docs/validators/register-vali/_index.md
+++ b/content/docs/validators/register-vali/_index.md
@@ -99,8 +99,8 @@ aut validator register <ENODE_URL> <PROOF> | aut tx sign - | aut tx send -
 ```
 
 where:
-- `<ENODE_URL>`: the enode url returned in Step 1.
-- `<PROOF>`: the proof of enode ownership generated in Step 2.
+- `<ENODE_URL>`: the enode url returned in Step 2.
+- `<PROOF>`: the proof of enode ownership generated in Step 1.
 
 Once the transaction is finalized (use `aut tx wait <txid>` to wait for it to be included in a block and return the status), the node is registered as a validator in the active state. It will become eligible for [selection to the consensus committee](/concepts/validator/#eligibility-for-selection-to-consensus-committee) once stake has been bonded to it.
 

--- a/content/docs/validators/register-vali/_index.md
+++ b/content/docs/validators/register-vali/_index.md
@@ -35,7 +35,7 @@ docker run -t -i --volume $(pwd)/autonity-chaindata:/autonity-chaindata --name a
 ```
 
 where
-    - `<NODE_KEY_PATH>`: is the path to the private key file of the P2P node key (by default within the `autonity` subfolder of the `--datadir` specified when running the node`. (For setting the data directory see How to [Run Autonity](/node-operators/run-aut/).)
+    - `<NODE_KEY_PATH>`: is the path to the private key file of the P2P node key (by default within the `autonity` subfolder of the `--datadir` specified when running the node. (For setting the data directory see How to [Run Autonity](/node-operators/run-aut/).)
     - `<TREASURY_ACCOUNT_ADDRESS>`: is treasury account address (i.e. the address you are using to submit the registration transaction from the local machine).
 
 You should see something like this:


### PR DESCRIPTION
* tiny fix to a quotation mark
* Step 3 refers to `<ENODE_URL>` and `<PROOF>`, but points to the wrong steps. Corrected here. (This seems to have caused the confusion highlighted here: https://discord.com/channels/753937111781998605/1067051261993680996/1080859127540101231)