### PR TITLE
Correct keyfile flag

### DIFF
--- a/content/docs/account-holders/create-acct/_index.md
+++ b/content/docs/account-holders/create-acct/_index.md
@@ -32,7 +32,7 @@ Confirm account password:
 A custom keyfile can be specified using the `--keyfile` flag:
 ```bash
 mkdir keystore
-aut account new --key-file ./keystore/alice.key
+aut account new --keyfile ./keystore/alice.key
 ```
 ```bash
 Password for new account:


### PR DESCRIPTION
Update Create account to correct legacy syntax of `--key-file` with `--keyfile`.

closes #51 