### PR TITLE
Update Reference, Web3 Namespace, issue #53

### DIFF
--- a/content/docs/reference/api/web3/_index.md
+++ b/content/docs/reference/api/web3/_index.md
@@ -8,11 +8,12 @@ description: >
 
 Autonity supports the following Geth Web3 APIs. Click on the links to go to the relevant Geth documentation: 
 
-- [admin namespace](https://geth.ethereum.org/docs/rpc/ns-admin)
-- [debug namespace](https://geth.ethereum.org/docs/rpc/ns-debug)
-- [eth namespace](https://geth.ethereum.org/docs/rpc/ns-eth)
-- [personal namespace](https://geth.ethereum.org/docs/rpc/ns-personal)
-- [txpool namespace](https://geth.ethereum.org/docs/rpc/ns-txpool)
+- [admin namespace](https://geth.ethereum.org/docs/interacting-with-geth/rpc/ns-admin)
+- [debug namespace](https://geth.ethereum.org/docs/interacting-with-geth/rpc/ns-debug)
+- [eth namespace](https://geth.ethereum.org/docs/interacting-with-geth/rpc/ns-eth)
+- [net namespace](https://geth.ethereum.org/docs/interacting-with-geth/rpc/ns-net)
+- [personal namespace](https://geth.ethereum.org/docs/interacting-with-geth/rpc/ns-personal)
+- [txpool namespace](https://geth.ethereum.org/docs/interacting-with-geth/rpc/ns-txpool)
 
 Autonity does not support the Geth Web3 APIs:
 


### PR DESCRIPTION
Edits to:

- correct out-of-date links to upstream docs for supported Geth web3 namespaces: `admin`, `debug`, `eth`, `net`, `personal`, `txpool` namespace.
 - add missing entry for the `net` namespace.