### PR TITLE
Networks, config, add operator, treasury, genesis validator entries

### DIFF
--- a/content/docs/networks/testnet-bakerloo/_index.md
+++ b/content/docs/networks/testnet-bakerloo/_index.md
@@ -40,9 +40,14 @@ The network's genesis configuration is:
 | `config.autonity.delegationRate`   | `1000` (10%)                  |                |
 | `config.autonity.treasuryFee`      | `10000000000000000` (1%)      |
 | `config.autonity.minBaseFee`       | `500000000` (0.5 GWei)        |
-| `config.autonity.operator`         |  |
-| `config.autonity.treasury`         |  |
-| `config.autonity.validators`       |  |
+| `config.autonity.operator`         | `0x293039dDC627B1dF9562380c0E5377848F94325A` |
+| `config.autonity.treasury`         | `0x7f1B212dcDc119a395Ec2B245ce86e9eE551043E` |
+| `config.autonity.validators`       | `enode://181dd52828614267b2e3fe16e55721ce4ee428a303b89a0cba3343081be540f28a667c9391024718e45ae880088bd8b6578e82d395e43af261d18cedac7f51c3@35.246.21.247:30303` |
+|  | `enode://e3b8ea9ddef567225530bcbae68af5d46f59a2b39acc04113165eba2744f6759493027237681f10911d4c12eda729c367f8e64dfd4789c508b7619080bb0861b@35.189.64.207:30303` |
+|  |`enode://00c6c1704c103e74a26ad072aa680d82f6c677106db413f0afa41a84b5c3ab3b0827ea1a54511f637350e4e31d8a87fdbab5d918e492d21bea0a399399a9a7b5@34.105.163.137:30303` |
+|  | `enode://dffaa985bf36c8e961b9aa7bcdd644f1ad80e07d7977ce8238ac126d4425509d98da8c7f32a3e47e19822bd412ffa705c4488ce49d8b1769b8c81ee7bf102249@35.177.8.113:30308` |
+|  | `enode://1bd367bfb421eb4d21f9ace33f9c3c26cd1f6b257cc4a1af640c9af56f338d865c8e5480c7ee74d5881647ef6f71d880104690936b72fdc905886e9594e976d1@35.179.46.181:30309` |
+|  | `enode://a7465d99513715ece132504e47867f88bb5e289b8bca0fca118076b5c733d901305db68d1104ab838cf6be270b7bf71e576a44644d02f8576a4d43de8aeba1ab@3.9.98.39:30310` |
 
 Note:
 

--- a/content/docs/networks/testnet-piccadilly/_index.md
+++ b/content/docs/networks/testnet-piccadilly/_index.md
@@ -39,9 +39,14 @@ A public testnet for participants interested in:
 | `config.autonity.delegationRate`   | `1000` (10%)                  |
 | `config.autonity.treasuryFee`      | `10000000000000000` (1%)      |
 | `config.autonity.minBaseFee`       | `500000000` (0.5 GWei)        |
-| `config.autonity.operator`         |  |  |
-| `config.autonity.treasury`         |  |  |
-| `config.autonity.validators`       |  |  |
+| `config.autonity.operator`         | `0xd32C0812Fa1296F082671D5Be4CbB6bEeedC2397` |
+| `config.autonity.treasury`         | `0xF74c34Fed10cD9518293634C6f7C12638a808Ad5` |
+| `config.autonity.validators`       | `enode://d4dc137f987e17155a69b31e566494c16edafd228912483cc519a48ce85864781faccc38141cc0eb1df8cdb28b9b3ccd10e1c298bac78ac43bbe5804021c1152@34.142.71.5:30303` |
+|  | `enode://74a4f767ad2f3f607a2db06732b44e6c61a68cae1959b331c18aea6256aae16bded31ba40dd85dcc4d719baaeb29f918726d19fa51b5d8174b27da0d7593e19b@34.142.33.89:30303` |
+|  | `enode://0ddc30943837f9416f563063ed5d409aca37780b8b8f939ef9f4b7901b9eb94c09d7ba2af27f70b33d76e74403d00021c13ebc4943ad46bc1e5051689cd862b8@35.234.131.29:30303` |
+|  | `enode://9435658d26e5daf30261648504560f6375b24cdf0e4403613d44ebc4020489cc67ac82ababe7928d63d9f113c67b946845d18db935abe3d241e665114fc75e94@35.177.73.222:30303` |
+|  | `enode://fe2c621f2b660725a3d529b3eefd780e90bb86e9eb4b7136c0b00a7365260a478b9b8941f1a65c6d4d77bff1b2e22eb6d781f5cc86401d60b373c6d4155c189a@3.10.195.56:30304` |
+|  | `enode://6ab1e6bbf5897e1a24ccf8d8718615ec972ffd54d99c3e46f4517d5602e8bf7110e2e5e2c2e584795e45e2e842172de044b4df165a7082133c6697b632da8282@18.168.88.205:30305` |
 
 Note:
 


### PR DESCRIPTION
Edit Networks section for the Bakerloo and Piccadilly Testnets to add missing entries for operator and treasury accounts, and enodes of the genesis validator set.

Data taken from and verified agains AGC config for the testnet flags.

- Bakerloo: https://github.com/autonity/autonity/blob/e1e8e257c45f28b2553edbeca32c6e9f60523d83/params/config.go#L127
- Piccadilly: https://github.com/autonity/autonity/blob/e1e8e257c45f28b2553edbeca32c6e9f60523d83/params/config.go#L66 

closes #13 