### PR TITLE
Add plausible integration 

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,6 @@
 [submodule "themes/docsy"]
 	path = themes/docsy
 	url = https://github.com/google/docsy.git
+[submodule "themes/plausible-hugo"]
+	path = themes/plausible-hugo
+	url = https://github.com/divinerites/plausible-hugo.git

--- a/config.toml
+++ b/config.toml
@@ -1,7 +1,7 @@
 baseURL = 'https://docs.autonity.org/'
 enableGitInfo = true
 languageCode = 'en-gb'
-theme = "docsy"
+theme = ["docsy", "plausible-hugo"]
 title = 'docs.autonity.org'
 
 # Move the default contentDir one level down to facilitate a "docs only" site
@@ -36,3 +36,8 @@ navbar_logo = true
   [markup.goldmark]
     [markup.goldmark.renderer]
       unsafe = true
+
+[params.plausible]
+  enable = true  # Whether to enable plausible tracking
+  domain = "docs.autonity.org"  # Plausible "domain" name/id in your dashboard
+  gitstar = false

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -1,0 +1,55 @@
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
+{{ hugo.Generator }}
+{{ range .AlternativeOutputFormats -}}
+<link rel="{{ .Rel }}" type="{{ .MediaType.Type }}" href="{{ .Permalink | safeURL }}">
+{{ end -}}
+
+{{ $outputFormat := partial "outputformat.html" . -}}
+{{ if and hugo.IsProduction (ne $outputFormat "print") -}}
+<meta name="robots" content="index, follow">
+{{ else -}}
+<meta name="robots" content="noindex, nofollow">
+{{ end -}}
+
+{{ partialCached "favicons.html" . }}
+<title>
+  {{- if .IsHome -}}
+    {{ .Site.Title -}}
+  {{ else -}}
+    {{ with .Title }}{{ . }} | {{ end -}}
+    {{ .Site.Title -}}
+  {{ end -}}
+</title>
+{{ $desc := .Page.Description | default (.Page.Content | safeHTML | truncate 150) -}}
+<meta name="description" content="{{ $desc }}">
+{{ template "_internal/opengraph.html" . -}}
+{{ template "_internal/schema.html" . -}}
+{{ template "_internal/twitter_cards.html" . -}}
+{{ partialCached "head-css.html" . "asdf" -}}
+<script
+  src="https://code.jquery.com/jquery-3.6.0.min.js"
+  integrity="sha384-vtXRMe3mGCbOeY7l30aIg8H9p3GdeSe4IFlP6G8JMa7o7lXvnz3GFKzPxzJdPfGK"
+  crossorigin="anonymous"></script>
+{{ if .Site.Params.offlineSearch -}}
+<script defer
+  src="https://unpkg.com/lunr@2.3.9/lunr.min.js"
+  integrity="sha384-203J0SNzyqHby3iU6hzvzltrWi/M41wOP5Gu+BiJMz5nwKykbkUx8Kp7iti0Lpli"
+  crossorigin="anonymous"></script>
+{{ end -}}
+
+{{ if .Site.Params.prism_syntax_highlighting -}}
+<link rel="stylesheet" href="{{ "/css/prism.css" | relURL }}"/>
+{{ end -}}
+
+{{ partial "hooks/head-end.html" . -}}
+{{ partial "plausible_head.html" . }}
+
+{{/* To comply with GDPR, cookie consent scripts places in head-end must execute before Google Analytics is enabled */ -}}
+{{ if hugo.IsProduction -}}
+  {{ if hasPrefix .Site.GoogleAnalytics "G-" -}}
+    {{ template "_internal/google_analytics.html" . -}}
+  {{ else -}}
+    {{ template "_internal/google_analytics_async.html" . -}}
+  {{ end -}}
+{{ end -}}


### PR DESCRIPTION
### Brief Description:
To use site-analytics data, configure the simple, privacy friendly Plausible Analytics service for this site.
This feature has on impact on current and future users.

Resolves: https://github.com/autonity/docs.autonity.org/issues/65

