### PR TITLE
Validator Commission Rate Change - clarify delay in applying change 

### DIFF
--- a/content/docs/delegators/bond-stake/_index.md
+++ b/content/docs/delegators/bond-stake/_index.md
@@ -53,7 +53,7 @@ aut validator info --validator 0x9fd408Bdb83Be1c8504Ff13eBcCe7f490DCCC2cF
 }
 ```
 
-{{< alert name="Note" >}}
+{{< alert title="Note" >}}
 If you interact with a specific validator very frequently, you might consider making it the default by adding an entry such as
 
 ```
@@ -82,8 +82,8 @@ The `aut validator bond` command creates a transaction that bonds the caller's n
 aut validator bond --validator <VALIDATOR_IDENTIFIER_ADDRESS> <AMOUNT> | aut tx sign - | aut tx send -
 ```
 
-{{< alert name="Note" >}}
-Bonding requests are not processed until the end of the current epoch.  The newton to be bonded will be deducted from your balance, but your [liquid newton balance](/delegators/transfer-lntn) will not be affected until the epoch
+{{< alert title="Note" >}}
+Bonding requests are not processed until the end of the current epoch.  The newton to be bonded will be deducted from your balance, but your [liquid newton balance](/delegators/transfer-lntn) will not be affected until the epoch end.
 
 (Pending and historical bonding requests can be queried using the [getBondingReq](/reference/api/) api call or the `aut protocol get-bonding-req` command)
 {{< /alert >}}
@@ -96,6 +96,6 @@ The `aut validator unbond` command creates a transaction that unbonds the caller
 aut validator unbond --validator <VALIDATOR_IDENTIFIER_ADDRESS> <AMOUNT> | aut tx sign - | aut tx send -
 ```
 
-{{< alert name="Note" >}}
+{{< alert title="Note" >}}
 Like bonding requests, unbonding does not complete immediately.  After an unbonding period, the Newton will be returned to the caller.  See the [staking section](/concepts/staking/) for further details.
 {{< /alert >}}

--- a/content/docs/reference/api/aut/op-prot/_index.md
+++ b/content/docs/reference/api/aut/op-prot/_index.md
@@ -699,7 +699,8 @@ The block finalization function, invoked each block after processing every trans
 - checks if the block number is the last epoch block number and if so, then:
     - performs the staking rewards redistribution, redistributing the available reward amount per protocol and emitting a `Rewarded` event for each distribution
     - sets `epochReward` to `0`
-    - applies any staking transitions - pending bonding and unbonding requests tracked in `Staking` darta structures in memory
+    - applies any staking transitions - pending bonding and unbonding requests tracked in `Staking` data structures in memory
+    - applies any validator commission rate changes - pending rate change requests tracked in `CommissionRateChangeRequest` data structures in memory
     - selects the consensus committee for the following epoch, invoking the [`computeCommittee`](/reference/api/aut/op-prot/#computecommittee) function
     - assigns the `lastEpochBlock` state variable the value of the current block number.
 

--- a/content/docs/validators/change-commission-rate/_index.md
+++ b/content/docs/validators/change-commission-rate/_index.md
@@ -37,6 +37,11 @@ description: >
     0xdbc9a27a2f7b53d9eaa660add917ed61fe7213d1cdd826065d0e7af96674d725
 	```
 
+{{< alert title="Note" >}}
+Commission rate changes are subject to the same temporal [unbonding period](/concepts/staking/#unbondingperiod) constraint as staking transitions. On commit of the rate change transaction, the unbonding period is tracked and the rate change is applied at the end of the epoch in which the unbonding period expires.
+{{< /alert >}}
+
+
 2. (Optional) To verify the updated rate, use the `validator` command `info` to submit a call to query for validator metadata. It will return the validator metadata from system state, including the validator status:
 
 	```bash


### PR DESCRIPTION
**Context**

Commission rate changes are subject to the same unbonding period constraint as staking transitions. On commit of the rate change transaction, the unbonding period begins and the rate change is applied at the end of the epoch in which the unbonding period expires.

**Problem**

This is not clear in the docs.

**Fix**

This PR implements edits to clarify this as described in issue #68 .

Edits to:

- https://docs.autonity.org/validators/change-commission-rate/#change-validator-commission-rate (after Step 1.)
- https://docs.autonity.org/reference/api/aut/op-prot/#finalize  - add bullet point "applies any validator commission rate changes - pending rate change requests tracked in CommissionRateChangeRequest data structures in memory" 
- https://docs.autonity.org/concepts/validator/#validator-economics - clarify validator commission rate change, adding in section detailing this.
- Also, correct typos found in **Staking** section while reviewing issue.


closes #68
