### PR TITLE
only use berkley mono on the body

### DIFF
--- a/assets/scss/_styles_project.scss
+++ b/assets/scss/_styles_project.scss
@@ -72,6 +72,10 @@ footer.bg-dark.py-5.row.d-print-none {
     word-wrap: break-word;
 }
 
+body {
+    font-family: 'proxima nova', sans-serif;
+}
+
 /**
 * Fix word spacing for large header tags
 */
@@ -81,6 +85,7 @@ h3,
 .h1,
 .h2,
 .h3 {
+    font-family: 'berkeley mono';
     letter-spacing: -1px;
 }
 


### PR DESCRIPTION
Currently, monofonts are applied to the whole site. To make it easier for people to read, I've raised a PR to only apply mono font styles to headers.
![image](https://github.com/autonity/docs.autonity.org/assets/5268627/b8bddd5b-ab15-41a9-8b0b-570d8d1e599c)

