### PR TITLE
Networks, Piccadilly, correct network name and release version

### DIFF
--- a/content/docs/networks/testnet-piccadilly/_index.md
+++ b/content/docs/networks/testnet-piccadilly/_index.md
@@ -21,7 +21,7 @@ Piccadilly is for participants interested in:
 
 |**Field**|**Input**|
 |------|----------|
-|Network Name|`Autonity Piccadilly Testnet`|
+|Network Name|`Autonity Piccadilly (Barada) Testnet`|
 |New RPC URL|`https://rpc1.piccadilly.autonity.org/`|
 |ChainID |`65100001`|
 |Symbol|`ATN`|
@@ -68,7 +68,7 @@ The network bootnode addresses are:
 
 ## Release
 
-- The current iteration of the Piccadilly network is built using this Autonity Release: [v0.12.1 <i class='fas fa-external-link-alt'></i>](https://github.com/autonity/autonity/releases/tag/v0.12.1)
+- The current iteration of the Piccadilly network is built using this Autonity Release: [v0.12.2 <i class='fas fa-external-link-alt'></i>](https://github.com/autonity/autonity/releases/tag/v0.12.2)
 
 - The nodes are running this docker image release: `ghcr.io/autonity/autonity:latest`
 

--- a/content/docs/networks/testnet-piccadilly/_index.md
+++ b/content/docs/networks/testnet-piccadilly/_index.md
@@ -50,7 +50,7 @@ Piccadilly is for participants interested in:
 |  | `enode://9435658d26e5daf30261648504560f6375b24cdf0e4403613d44ebc4020489cc67ac82ababe7928d63d9f113c67b946845d18db935abe3d241e665114fc75e94@35.177.73.222:30303` |
 |  | `enode://fe2c621f2b660725a3d529b3eefd780e90bb86e9eb4b7136c0b00a7365260a478b9b8941f1a65c6d4d77bff1b2e22eb6d781f5cc86401d60b373c6d4155c189a@3.10.195.56:30304` |
 |  | `enode://6ab1e6bbf5897e1a24ccf8d8718615ec972ffd54d99c3e46f4517d5602e8bf7110e2e5e2c2e584795e45e2e842172de044b4df165a7082133c6697b632da8282@18.168.88.205:30305` |
-| `config.oracle.symbols`       | `["AUD-USD", "CAD-USD", "EUR-USD", "GBP-USD", "JPY-USD", "SEK-USD", "ATN-USD", "NTN-USD"]`        |
+| `config.oracle.symbols`       | `["AUD-USD", "CAD-USD", "EUR-USD", "GBP-USD", "JPY-USD", "SEK-USD", "ATN-USD", "NTN-USD", "ATN-NTN"]`        |
 | `config.oracle.votePeriod`       | `30` (30 blocks)       |
 
 Note:


### PR DESCRIPTION
@raj-shekhar1 @lorenzo-dev1 please review

* official name is brought in line with Chainlist entries, to include the protocol version name Barada
* ATN-NTN pair is added to the Oracle config
* release version is v0.12.2

FYSA @flofrie - follow-on PR from your PR to #120 - for this update to Piccadilly network page
