### PR TITLE
Validator oboarding suggestions

### DIFF
--- a/content/docs/node-operators/install-aut/_index.md
+++ b/content/docs/node-operators/install-aut/_index.md
@@ -172,7 +172,7 @@ The following should be installed in order to build the Autonity Go Client:
 You should now be able to execute the `autonity` command.  Verify your installation by executing `autonity version` to return the client version and executable build details:
 
 ```bash
-./autonity version
+$ ./autonity version
 ```
 ```
 Autonity
@@ -190,7 +190,7 @@ GOROOT=/usr/local/go
 If using Docker, the setup of the image can be verified with:
 
 ```bash
-docker run --rm ghcr.io/autonity/autonity:latest version
+$ docker run --rm ghcr.io/autonity/autonity:latest version
 ```
 ```
 Autonity

--- a/content/docs/node-operators/install-aut/_index.md
+++ b/content/docs/node-operators/install-aut/_index.md
@@ -128,7 +128,7 @@ sudo systemctl restart docker
     ```bash
     docker images --digests ghcr.io/autonity/autonity
     REPOSITORY                               TAG       DIGEST                                                                    IMAGE ID       CREATED        SIZE
-    ghcr.io/autonity/autonity                latest    sha256:0eb561ce19ed3617038b022db89586f40abb9580cb0c4cd5f28a7ce74728a3d4   3375da450343   3 weeks ago    51.7MB
+    ghcr.io/autonity/autonity                latest    sha256:7298a5fb9834b8cc281b81df1153fcf2f955a292bf3bd5e5d3eb3f80b52f0727   3375da450343   3 weeks ago    54.4MB
     ```
 
 {{% pageinfo %}}
@@ -172,7 +172,7 @@ The following should be installed in order to build the Autonity Go Client:
 You should now be able to execute the `autonity` command.  Verify your installation by executing `autonity version` to return the client version and executable build details:
 
 ```bash
-$ ./autonity version
+./autonity version
 ```
 ```
 Autonity
@@ -190,7 +190,7 @@ GOROOT=/usr/local/go
 If using Docker, the setup of the image can be verified with:
 
 ```bash
-$ docker run --rm ghcr.io/autonity/autonity:latest version
+docker run --rm ghcr.io/autonity/autonity:latest version
 ```
 ```
 Autonity

--- a/content/docs/oracle/install-oracle/_index.md
+++ b/content/docs/oracle/install-oracle/_index.md
@@ -225,6 +225,15 @@ $ ./autoracle version
 v0.1.4
 ```
 
+If using Docker, the setup of the Bakerloo image can be verified with:
+
+```bash
+docker run --rm ghcr.io/autonity/autonity-oracle-bakerloo:latest version 
+```
+```
+v0.1.4
+```
+
 {{< alert title="Note" >}}
 The output above will vary depending on the version of the Autonity Oracle Server you have installed.  Confirm that the "Version" field is consistent with the version you expect.
 {{< /alert >}}

--- a/content/docs/oracle/run-oracle/_index.md
+++ b/content/docs/oracle/run-oracle/_index.md
@@ -123,17 +123,18 @@ If plugins for external data sources or the symbols for which oracle server prov
 
    where:
    
-   - `<ORACLE_CONTAINER_NAME>` is the name you are specifying for the container, i.e. `oracle-server-bakerloo` or `oracle-server-piccadilly`
-   - `<DOCKER_IMAGE>` is the Docker image name, i.e. `ghcr.io/autonity/autonity-oracle-bakerloo` or `ghcr.io/autonity/autonity-oracle-piccadilly`
    - `<ORACLE_KEYFILE>` specifies the path to your oracle server key file. E.g. `../aut/keystore/oracle.key`
    - `<PLUGINS_CONF_FILE>` is the path to the oracle server configuration file `plugins-conf.yml`. E.g. `./plugins-conf.yml`.
+   - `<ORACLE_CONTAINER_NAME>` is the name you are specifying for the container, i.e. `oracle-server-bakerloo` or `oracle-server-piccadilly`
+   - `<DOCKER_IMAGE>` is the Docker image name, i.e. `ghcr.io/autonity/autonity-oracle-bakerloo` or `ghcr.io/autonity/autonity-oracle-piccadilly`
    - `<PWD>` is the password to your oracle server key file
-   - `<WS_ADDRESS>` is the WebSocket IP Address of your connected Autonity Go Client node (see [install Autonity, networks](/node-operators/install-aut/#network). 
+   - `<WS_ADDRESS>` is the WebSocket IP Address of your connected Autonity Go Client node (e.g. "ws://172.17.0.2:8546", see [install Autonity, networks](/node-operators/install-aut/#network)). 
 
    See the [Autonity Oracle Server command-line reference](/reference/cli/oracle/) for the full set of available flags.
 
 {{< alert title="Info" >}}
-AOS requires an accessible `ws/wss` AGC endpoint. If you are also running AGC in docker and facing issues in connecting AOS to it, then see docker docs [Networking <i class='fas fa-external-link-alt'></i>](https://docs.docker.com/network/).  
+AOS requires an accessible `ws/wss` AGC endpoint. If you are also running AGC in docker and facing issues in connecting AOS to it, please execute the following command to correctly identify the IP address required for the `<WS_ADDRESS>`: `docker inspect -f '{{.NetworkSettings.IPAddress}}' <container_id_or_name>`
+   
 {{< /alert >}}
  
 On running the Docker you should see something like:

--- a/content/docs/validators/register-vali/_index.md
+++ b/content/docs/validators/register-vali/_index.md
@@ -34,7 +34,7 @@ autonity genOwnershipProof --nodekey <NODE_KEY_PATH> --oraclekey <ORACLE_KEY_PAT
 If you are running the Autonity Go Client in a docker container, setup as described in the [Run Autonity section](../../node-operators/run-aut#run-docker) (i.e. with the `autonity-chaindata` directory mapped to a host directory of the same name), the proof can be generated as follows:
 
 ```bash
-docker run -t -i --volume $(pwd)/autonity-chaindata:/autonity-chaindata --name autonity-proof --rm ghcr.io/autonity/autonity:latest genOwnershipProof --nodekey ./autonity-chaindata/autonity/nodekey --oraclekey <ORACLE_KEY_PATH> <TREASURY_ACCOUNT_ADDRESS>
+docker run -t -i --volume $(pwd)/autonity-chaindata:/autonity-chaindata --volume <ORACLE_KEY_PATH>:/oracle.key --name autonity-proof --rm ghcr.io/autonity/autonity:latest genOwnershipProof --nodekey ./autonity-chaindata/autonity/nodekey --oraclekey oracle.key <TREASURY_ACCOUNT_ADDRESS>
 ```
 
 where:


### PR DESCRIPTION
I have included some feedback on using docker for the AGC and for the AOS to run a node e2e.

- Updated the image hash to align with latest release and image size
- Added a verification command to check Oracle version if using Docker 
- Rearranged the order of variables explanation when spinning up Oracle to match docker command above
- Added example WS endpoint 
- Added volume mount for oracle key when generating enode proof with docker