### PR TITLE
Edit Pause and Reactivate a Validator of issue #133

### DIFF
--- a/content/docs/validators/pause-vali/_index.md
+++ b/content/docs/validators/pause-vali/_index.md
@@ -12,7 +12,12 @@ description: >
 - A running instance of `aut` for submitting transactions from your account configured as described in [Submit a transaction from Autonity Utility Tool (aut)](/account-holders/submit-trans-aut/).
 - Your validator's validator's [`treasury account`](/concepts/validator/#treasury-account) is [funded](/account-holders/fund-acct/) with auton to pay for transaction gas costs.
 
-{{< alert title="Note" >}}See the [Validator](/concepts/validator/) section for an explanation of the validator, a description of the [validator lifecycle](/concepts/validator/#validator-lifecycle), and [validator pausing](/concepts/validator/#validator-pausing).{{< /alert >}}
+{{< alert title="Note" >}}
+See the [Validator](/concepts/validator/) section for an explanation of the validator, a description of the [validator lifecycle](/concepts/validator/#validator-lifecycle), and [validator pausing](/concepts/validator/#validator-pausing).
+
+Note that the pause and reactivation of a validator will become effective at the end of the current epoch (i.e. the epoch in which the transaction is processed). The change in validator state is applied before the committee is selected for the following epoch is selected, ensuring that the validator is either ignored (if paused) or included (if reactivated).
+
+{{< /alert >}}
 
 ## Pause as a validator
 

--- a/content/docs/validators/pause-vali/_index.md
+++ b/content/docs/validators/pause-vali/_index.md
@@ -16,7 +16,6 @@ description: >
 See the [Validator](/concepts/validator/) section for an explanation of the validator, a description of the [validator lifecycle](/concepts/validator/#validator-lifecycle), and [validator pausing](/concepts/validator/#validator-pausing).
 
 Note that the pause and reactivation of a validator will become effective at the end of the current epoch (i.e. the epoch in which the transaction is processed). The change in validator state is applied before the committee is selected for the following epoch is selected, ensuring that the validator is either ignored (if paused) or included (if reactivated).
-
 {{< /alert >}}
 
 ## Pause as a validator


### PR DESCRIPTION
A PR to clarify the Validators Guide page, Pause and Reactivate a Validator, for issue #133 .

The PR edits the leading Note box to add a paragraph beginning "Note that the pause and reactivation...":

```
{{< alert title="Note" >}}
See the [Validator](/concepts/validator/) section for an explanation of the validator, a description of the [validator lifecycle](/concepts/validator/#validator-lifecycle), and [validator pausing](/concepts/validator/#validator-pausing).

Note that the pause and reactivation of a validator will become effective at the end of the current epoch (i.e. the epoch in which the transaction is processed). The change in validator state is applied before the committee is selected for the following epoch is selected, ensuring that the validator is either ignored (if paused) or included (if reactivated).

{{< /alert >}}
```

To add this to the Note box is consistent with the guide's style - i.e. all of the Validators guide pages use a leading Note box for such contextual information.