### PR TITLE
Edit Autonity Contract Interface for aut `v0.3.0` and remove commented out `nodejsconsole` commands

### DIFF
--- a/content/docs/reference/api/aut/_index.md
+++ b/content/docs/reference/api/aut/_index.md
@@ -234,7 +234,9 @@ $ aut token balance-of --token 0xf4D9599aFd90B5038b18e3B551Bc21a97ed21c37 0x11a8
 {{< /tab >}}
 {{< /tabpane >}}
 
-{{< alert title="Info" >}}All Liquid Newton balances for an account can be returned in one call using the `aut` command `aut account lntn-balances [OPTIONS] ACCOUNT`.{{< /alert >}}
+{{< alert title="Info" >}}
+All Liquid Newton balances for an account can be returned in one call using the `aut` command `aut account lntn-balances [OPTIONS] ACCOUNT`.
+{{< /alert >}}
 
 
 ## bond
@@ -372,18 +374,21 @@ Returns a `Config` object consisting of:
 
 | Field | Datatype | Description |
 | --| --| --|
-| `operatorAccount` | `address` | the address of the Autonity governance account |
-| `treasuryAccount` | `address payable` | the address of the Autonity Treasury account for community funds |
-| `accountabilityContract` | `address` | the address of the Autonity Accountability Contract |
-| `oracleContract` | `address` | the address of the Autonity Oracle Contract |
 | `treasuryFee` | `uint256` | the percentage of staking rewards deducted from staking rewards and sent to the Autonity Treasury account for community funding before staking rewards are distributed |
 | `minBaseFee` | `uint256` | the minimum gas price for a unit of gas used to compute a transaction on the network, denominated in [ton](/glossary/#ton) |
 | `delegationRate` | `uint256` | the percentage of staking rewards deducted by validators as a commission from delegated stake |
-| `epochPeriod` | `uint256` | the period of time for which a consensus committee is elected, defined as a number of blocks |
 | `unbondingPeriod` | `uint256` | the period of time for which bonded stake must wait before it can be redeemed for Newton after processing a stake redeem transaction, defined as a number of blocks |
+| `treasuryAccount` | `address payable` | the address of the Autonity Treasury account for community funds |
+| `accountabilityContract` | `address` | the address of the Autonity Accountability Contract |
+| `oracleContract` | `address` | the address of the Autonity Oracle Contract |
+| `acuContract` | `address` | the address of the Autonity ASM ACU Contract |
+| `supplyControlContract` | `address` | the address of the Autonity ASM Supply Control Contract |
+| `stabilizationContract` | `address` | the address of the Autonity ASM Stabilization Contract |
+| `operatorAccount` | `address` | the address of the Autonity governance account |
+| `epochPeriod` | `uint256` | the period of time for which a consensus committee is elected, defined as a number of blocks |
+| `blockPeriod` | `uint256` | the minimum time interval between two consecutive blocks, measured in seconds |
 | `committeeSize` | `uint256` | the maximum number of validators that may be members of a consensus committee on the network |
 | `contractVersion` | `uint256 ` | the version number of the Autonity Protocol Contract. An integer value set by default to `1` and incremented by `1` on contract upgrade |
-| `blockPeriod` | `uint256` | the minimum time interval between two consecutive blocks, measured in seconds |
 
 ### Usage
 
@@ -402,21 +407,32 @@ aut protocol config [OPTIONS]
 {{< tab header="aut" >}}
 $ aut protocol config -r https://rpc1.piccadilly.autonity.org
 {
-  "operator_account": "0xd32C0812Fa1296F082671D5Be4CbB6bEeedC2397",
-  "treasury_account": "0xF74c34Fed10cD9518293634C6f7C12638a808Ad5",
-  "treasury_fee": 10000000000000000,
-  "min_basefee": 500000000,
-  "delegation_rate": 1000,
-  "epoch_period": 1800,
-  "unbonding_period": 21600,
-  "committee_size": 100,
-  "contract_version": 1,
-  "block_period": 1
+  "policy": {
+    "treasury_fee": 10000000000000000,
+    "min_basefee": 500000000,
+    "delegation_rate": 1000,
+    "unbonding_period": 21600,
+    "treasury_account": "0xF74c34Fed10cD9518293634C6f7C12638a808Ad5"
+  },
+  "contracts": {
+    "accountability_contract": "0x5a443704dd4B594B382c22a083e2BD3090A6feF3",
+    "oracle_contract": "0x47e9Fbef8C83A1714F1951F142132E6e90F5fa5D",
+    "acu_contract": "0x8Be503bcdEd90ED42Eff31f56199399B2b0154CA",
+    "supply_control_contract": "0x47c5e40890bcE4a473A49D7501808b9633F29782",
+    "stabilization_contract": "0x29b2440db4A256B0c1E6d3B4CDcaA68E2440A08f"
+  },
+  "protocol": {
+    "operator_account": "0xd32C0812Fa1296F082671D5Be4CbB6bEeedC2397",
+    "epoch_period": 1800,
+    "block_period": 1,
+    "committee_size": 100
+  },
+  "contract_version": 1
 }
 {{< /tab >}}
 {{< tab header="RPC" >}}
 curl -X GET 'https://rpc1.piccadilly.autonity.org/'  --header 'Content-Type: application/json' --data '{"jsonrpc":"2.0", "method":"aut_config", "params":[], "id":1}'
-{"jsonrpc":"2.0","id":1,"result":["0xd32c0812fa1296f082671d5be4cbb6beeedc2397","0xf74c34fed10cd9518293634c6f7c12638a808ad5",10000000000000000,500000000,1000,1800,21600,100,1,1]}
+{"jsonrpc":"2.0","id":1,"result":[{"treasuryFee":10000000000000000,"minBaseFee":500000000,"delegationRate":1000,"unbondingPeriod":21600,"treasuryAccount":"0xf74c34fed10cd9518293634c6f7c12638a808ad5"},{"accountabilityContract":"0x5a443704dd4b594b382c22a083e2bd3090a6fef3","oracleContract":"0x47e9fbef8c83a1714f1951f142132e6e90f5fa5d","acuContract":"0x8be503bcded90ed42eff31f56199399b2b0154ca","supplyControlContract":"0x47c5e40890bce4a473a49d7501808b9633f29782","stabilizationContract":"0x29b2440db4a256b0c1e6d3b4cdcaa68e2440a08f"},{"operatorAccount":"0xd32c0812fa1296f082671d5be4cbb6beeedc2397","epochPeriod":1800,"blockPeriod":1,"committeeSize":100},1]}
 {{< /tab >}}
 {{< /tabpane >}}
 
@@ -595,6 +611,9 @@ None.
 ### Usage
 
 {{< tabpane langEqualsHeader=true >}}
+{{< tab header="aut" >}}
+aut protocol get-block-period [OPTIONS]
+{{< /tab >}}
 {{< tab header="RPC" >}}
 {"method": "aut_getBlockPeriod", "params":[]}
 {{< /tab >}}
@@ -603,6 +622,10 @@ None.
 ### Example
 
 {{< tabpane langEqualsHeader=true >}}
+{{< tab header="aut" >}}
+aut protocol get-block-period --rpc-endpoint https://rpc1.piccadilly.autonity.org
+1
+{{< /tab >}}
 {{< tab header="RPC" >}}
 curl -X GET 'https://rpc1.piccadilly.autonity.org/'  --header 'Content-Type: application/json' --data '{"method":"aut_getBlockPeriod", "params":[], "jsonrpc":"2.0", "id":1}'
 {"jsonrpc":"2.0","id":1,"result":1}
@@ -755,6 +778,9 @@ Returns the unique identifier of the epoch block epoch associated with a block a
 ### Usage
 
 {{< tabpane langEqualsHeader=true >}}
+{{< tab header="aut" >}}
+aut protocol get-epoch-from-block [OPTIONS] BLOCK
+{{< /tab >}}
 {{< tab header="RPC" >}}
 {"method": "aut_getEpochFromBlock", "params":[_block]}
 {{< /tab >}}
@@ -763,7 +789,10 @@ Returns the unique identifier of the epoch block epoch associated with a block a
 ### Example
 
 {{< tabpane langEqualsHeader=true >}}
-
+{{< tab header="aut" >}}
+aut protocol get-epoch-from-block --rpc-endpoint https://rpc1.piccadilly.autonity.org 3293857
+1829
+{{< /tab >}}
 {{< tab header="RPC" >}}
 curl --location --request GET 'https://rpc1.bakerloo.autonity.org/' \
 --header 'Content-Type: application/json' \
@@ -795,6 +824,9 @@ None.
 ### Usage
 
 {{< tabpane langEqualsHeader=true >}}
+{{< tab header="aut" >}}
+aut protocol get-epoch-period [OPTIONS]
+{{< /tab >}}
 {{< tab header="RPC" >}}
 {"method": "aut_getEpochPeriod", "params":[]}
 {{< /tab >}}
@@ -803,6 +835,10 @@ None.
 ### Example
 
 {{< tabpane langEqualsHeader=true >}}
+{{< tab header="aut" >}}
+aut protocol get-epoch-period --rpc-endpoint https://rpc1.piccadilly.autonity.org
+1800
+{{< /tab >}}
 {{< tab header="RPC" >}}
 curl -X GET 'https://rpc1.piccadilly.autonity.org/'  --header 'Content-Type: application/json' --data '{"method":"aut_getEpochPeriod", "params":[], "jsonrpc":"2.0", "id":1}'
 {"jsonrpc":"2.0","id":1,"result":1800}
@@ -1104,6 +1140,82 @@ curl --location --request GET 'https://rpc1.bakerloo.autonity.org/' \
 {{< /tabpane >}}
 
 
+## getTreasuryAccount
+
+Returns the address of the Autonity treasury account.
+
+### Parameters
+
+None.
+
+### Response
+
+| Field | Datatype | Description |
+| --| --| --|
+| value | `address` | the Autonity treasury account address |
+
+### Usage
+
+{{< tabpane langEqualsHeader=true >}}
+{{< tab header="aut" >}}
+aut protocol get-treasury-account [OPTIONS]
+{{< /tab >}}
+{{< tab header="RPC" >}}
+{"method":"aut_getTreasuryAccount", "params":[]}
+{{< /tab >}}
+{{< /tabpane >}}
+
+### Example
+
+{{< tabpane langEqualsHeader=true >}}
+{{< tab header="aut" >}}
+aut protocol get-treasury-account -r https://rpc1.piccadilly.autonity.org/
+0xF74c34Fed10cD9518293634C6f7C12638a808Ad5
+{{< /tab >}}
+{{< tab header="RPC" >}}
+curl -X GET 'https://rpc1.piccadilly.autonity.org/'  --header 'Content-Type: application/json' --data '{"jsonrpc":"2.0", "method":"aut_getTreasuryAccount", "params":[], "id":1}'
+{"jsonrpc":"2.0","id":1,"result":"0xf74c34fed10cd9518293634c6f7c12638a808ad5"}
+{{< /tab >}}
+{{< /tabpane >}}
+
+## getTreasuryFee
+
+Returns the percentage of staking rewards deducted from staking rewards by the protocol. Treasury fees ared sent to the Autonity Treasury account for community funding before staking rewards are distributed.
+
+### Parameters
+
+None.
+
+### Response
+
+| Field | Datatype | Description |
+| --| --| --|
+| `treasuryFee` | `uint256` | the Autonity treasury account address. The value is returned in `10^18` format. |
+
+### Usage
+
+{{< tabpane langEqualsHeader=true >}}
+{{< tab header="aut" >}}
+aut protocol get-treasury-fee [OPTIONS]
+{{< /tab >}}
+{{< tab header="RPC" >}}
+{"method":"aut_getTreasuryFee", "params":[]}
+{{< /tab >}}
+{{< /tabpane >}}
+
+### Example
+
+{{< tabpane langEqualsHeader=true >}}
+{{< tab header="aut" >}}
+aut protocol get-treasury-fee -r https://rpc1.piccadilly.autonity.org/
+10000000000000000
+{{< /tab >}}
+{{< tab header="RPC" >}}
+curl -X GET 'https://rpc1.piccadilly.autonity.org/'  --header 'Content-Type: application/json' --data '{"jsonrpc":"2.0", "method":"aut_getTreasuryFee", "params":[], "id":1}'
+{"jsonrpc":"2.0","id":1,"result":10000000000000000}
+{{< /tab >}}
+{{< /tabpane >}}
+
 
 ## getUnbondingPeriod
 
@@ -1122,6 +1234,9 @@ None.
 ### Usage
 
 {{< tabpane langEqualsHeader=true >}}
+{{< tab header="aut" >}}
+aut protocol get-unbonding-period [OPTIONS]
+{{< /tab >}}
 {{< tab header="RPC" >}}
 {"method": "aut_getUnbondingPeriod", "params":[]}
 {{< /tab >}}
@@ -1130,6 +1245,10 @@ None.
 ### Example
 
 {{< tabpane langEqualsHeader=true >}}
+{{< tab header="aut" >}}
+aut protocol get-unbonding-period -r https://rpc1.piccadilly.autonity.org/
+21600
+{{< /tab >}}
 {{< tab header="RPC" >}}
 curl -X GET 'https://rpc1.piccadilly.autonity.org/'  --header 'Content-Type: application/json' --data '{"method":"aut_getUnbondingPeriod", "params":[], "jsonrpc":"2.0", "id":1}'
 {"jsonrpc":"2.0","id":1,"result":21600}
@@ -1243,6 +1362,11 @@ aut validator list [OPTIONS]
 {"method": "aut_getValidators", "params":[]}
 {{< /tab >}}
 {{< /tabpane >}}
+
+
+{{< alert title="Info" >}}
+`getValidators` can also be called using the `aut` command `aut protocol get-validators`.
+{{< /alert >}}
 
 ### Example
 

--- a/content/docs/reference/api/aut/op-prot/_index.md
+++ b/content/docs/reference/api/aut/op-prot/_index.md
@@ -124,6 +124,13 @@ The new total supply of auton available for minting can be retrieved from state 
 
 On a successful call the function emits a `Mint` event, logging: `recipient`, `amount`.
 
+#### Usage
+
+{{< alert title="Info" >}}
+The ASM Supply Control Contract Interface is not currently supported by `aut`.
+
+You can interact with the contract using the `aut contract` command group. See `aut contract tx -h` for how to submit a transaction calling the interface function.
+{{< /alert >}}
 
 ###  modifyBasket (ACU Contract)
 
@@ -144,6 +151,14 @@ None.
 #### Event
 
 None.
+
+#### Usage
+
+{{< alert title="Info" >}}
+The ASM ACU Contract Interface is not currently supported by `aut`.
+
+You can interact with the contract using the `aut contract` command group. See `aut contract tx -h` for how to submit a transaction calling the interface function.
+{{< /alert >}}
 
 
 ###  setAccountabilityContract
@@ -168,15 +183,7 @@ None.
 
 {{< tabpane langEqualsHeader=true >}}
 {{< tab header="aut" >}}
-
-{{< /tab >}}
-{{< /tabpane >}}
-
-#### Example
-
-{{< tabpane langEqualsHeader=true >}}
-{{< tab header="aut" >}}
-
+aut protocol set-accountability-contract [OPTIONS] CONTRACT-ADDRESS
 {{< /tab >}}
 {{< /tabpane >}}
 
@@ -203,15 +210,7 @@ None.
 
 {{< tabpane langEqualsHeader=true >}}
 {{< tab header="aut" >}}
-
-{{< /tab >}}
-{{< /tabpane >}}
-
-#### Example
-
-{{< tabpane langEqualsHeader=true >}}
-{{< tab header="aut" >}}
-
+aut protocol set-acu-contract [OPTIONS] CONTRACT-ADDRESS
 {{< /tab >}}
 {{< /tabpane >}}
 
@@ -322,19 +321,11 @@ None.
 
 #### Usage
 
-{{< tabpane langEqualsHeader=true >}}
-{{< tab header="aut" >}}
+{{< alert title="Info" >}}
+The ASM Stabilization Contract Interface is not currently supported by `aut`.
 
-{{< /tab >}}
-{{< /tabpane >}}
-
-#### Example
-
-{{< tabpane langEqualsHeader=true >}}
-{{< tab header="aut" >}}
-
-{{< /tab >}}
-{{< /tabpane >}}
+You can interact with the contract using the `aut contract` command group. See `aut contract tx -h` for how to submit a transaction calling the interface function.
+{{< /alert >}}
 
 
 ###  setMinCollateralizationRatio (ASM Stabilization Contract)
@@ -363,19 +354,11 @@ None.
 
 #### Usage
 
-{{< tabpane langEqualsHeader=true >}}
-{{< tab header="aut" >}}
+{{< alert title="Info" >}}
+The ASM Stabilization Contract Interface is not currently supported by `aut`.
 
-{{< /tab >}}
-{{< /tabpane >}}
-
-#### Example
-
-{{< tabpane langEqualsHeader=true >}}
-{{< tab header="aut" >}}
-
-{{< /tab >}}
-{{< /tabpane >}}
+You can interact with the contract using the `aut contract` command group. See `aut contract tx -h` for how to submit a transaction calling the interface function.
+{{< /alert >}}
 
 
 ###  setMinDebtRequirement (ASM Stabilization Contract)
@@ -398,20 +381,11 @@ None.
 
 #### Usage
 
-{{< tabpane langEqualsHeader=true >}}
-{{< tab header="aut" >}}
+{{< alert title="Info" >}}
+The ASM Stabilization Contract Interface is not currently supported by `aut`.
 
-{{< /tab >}}
-{{< /tabpane >}}
-
-#### Example
-
-{{< tabpane langEqualsHeader=true >}}
-{{< tab header="aut" >}}
-
-{{< /tab >}}
-{{< /tabpane >}}
-
+You can interact with the contract using the `aut contract` command group. See `aut contract tx -h` for how to submit a transaction calling the interface function.
+{{< /alert >}}
 
 
 ###  setMinimumBaseFee
@@ -442,14 +416,6 @@ aut protocol set-minimum-base-fee [OPTIONS] base-fee
 {{< /tab >}}
 {{< /tabpane >}}
 
-<!--
-{{< tab header="NodeJS Console" >}}
-autonity.setMinimumBaseFee(_price).send()
-{{< /tab >}}
-{{< tab header="RPC" >}}
-{"method": "aut_setMinimumBaseFee", "params":[_price]}
-{{< /tab >}}
--->
 
 #### Example
 
@@ -462,42 +428,6 @@ Enter passphrase (or CTRL-d to exit):
 {{< /tab >}}
 {{< /tabpane >}}
 
-<!--
-{{< tab header="NodeJS Console" >}}
-> autonity.setMinimumBaseFee(50000000).send({from: myAddress, gas: gas})
-{
-  blockHash: '0xb72f0acd971378eb60a011527b412f5f9d5ce096a42c2674b6b670967378ce5e',
-  blockNumber: 7247,
-  contractAddress: null,
-  cumulativeGasUsed: 30100,
-  effectiveGasPrice: 2500247492,
-  from: '0x11a87b260dd85ff7189d848fd44b28cc8505fa9c',
-  gasUsed: 30100,
-  logsBloom: '0x00004000000000000000000000020000000000000000000000000000000000000000000000000000000020000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000200000000000000000000000200000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000004000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000',
-  status: true,
-  to: '0xbd770416a3345f91e4b34576cb804a576fa48eb1',
-  transactionHash: '0xe102af7ad981f3e370a84c86669d8d309ab82c955a492d613904bef48a0babe0',
-  transactionIndex: 0,
-  type: '0x2',
-  events: {
-    MinimumBaseFeeUpdated: {
-      address: '0xBd770416a3345F91E4B34576cb804a576fa48EB1',
-      blockNumber: 7247,
-      transactionHash: '0xe102af7ad981f3e370a84c86669d8d309ab82c955a492d613904bef48a0babe0',
-      transactionIndex: 0,
-      blockHash: '0xb72f0acd971378eb60a011527b412f5f9d5ce096a42c2674b6b670967378ce5e',
-      logIndex: 0,
-      removed: false,
-      id: 'log_2f1e2457',
-      returnValues: [Result],
-      event: 'MinimumBaseFeeUpdated',
-      signature: '0x1f4d2fc7529047a5bd96d3229bfea127fd18b7748f13586e097c69fccd389128',
-      raw: [Object]
-    }
-  }
-}
-{{< /tab >}}
--->
 
 ###  setOperatorAccount
 
@@ -530,14 +460,6 @@ aut protocol set-operator-account [OPTIONS] OPERATOR-ADDRESS
 {{< /tab >}}
 {{< /tabpane >}}
 
-<!--
-{{< tab header="NodeJS Console" >}}
-autonity.setOperatorAccount(_account).send()
-{{< /tab >}}
-{{< tab header="RPC" >}}
-{"method": "aut_setOperatorAccount", "params":[_account]}
-{{< /tab >}}
--->
 
 #### Example
 
@@ -550,11 +472,6 @@ Enter passphrase (or CTRL-d to exit):
 {{< /tab >}}
 {{< /tabpane >}}
 
-<!--
-{{< tab header="NodeJS Console" >}}
-> autonity.setOperatorAccount('0x11a87b260dd85ff7189d848fd44b28cc8505fa9c').send({from: myAddress, gas: gas})
-{{< /tab >}}
--->
 
 ###  setOracleContract
 
@@ -584,17 +501,10 @@ None.
 
 {{< tabpane langEqualsHeader=true >}}
 {{< tab header="aut" >}}
-
+aut protocol set-oracle-contract [OPTIONS] CONTRACT-ADDRESS
 {{< /tab >}}
 {{< /tabpane >}}
 
-#### Example
-
-{{< tabpane langEqualsHeader=true >}}
-{{< tab header="aut" >}}
-
-{{< /tab >}}
-{{< /tabpane >}}
 
 
 ###  setStabilizationContract
@@ -619,17 +529,10 @@ None.
 
 {{< tabpane langEqualsHeader=true >}}
 {{< tab header="aut" >}}
-
+aut protocol set-stabilization-contract [OPTIONS] CONTRACT-ADDRESS
 {{< /tab >}}
 {{< /tabpane >}}
 
-#### Example
-
-{{< tabpane langEqualsHeader=true >}}
-{{< tab header="aut" >}}
-
-{{< /tab >}}
-{{< /tabpane >}}
 
 
 ###  setSupplyControlContract
@@ -654,17 +557,10 @@ None.
 
 {{< tabpane langEqualsHeader=true >}}
 {{< tab header="aut" >}}
-
+aut protocol set-supply-control-contract [OPTIONS] CONTRACT-ADDRESS
 {{< /tab >}}
 {{< /tabpane >}}
 
-#### Example
-
-{{< tabpane langEqualsHeader=true >}}
-{{< tab header="aut" >}}
-
-{{< /tab >}}
-{{< /tabpane >}}
 
 
 ### setSymbols (Oracle Contract)
@@ -1083,7 +979,6 @@ Based on the verification outcome, constraint checks are applied:
 
   - if `Accusation`, then:
     - the severity of the fault event is greater than the severity of the offender's current slashing history for the epoch
-    <!-- - the validator has not already been slashed for a fault with a higher severity in the proof's epoch. -->
     - the validator does not have a pending accusation being processed.
 
   - if `InnocenceProof`, then:


### PR DESCRIPTION
### Description

The [`aut v0.3.0` Release](https://github.com/autonity/aut/releases/tag/v0.3.0) has as part of its changes added commands for new Autonity Contract protocol functions.

This PR updates the docs to add this support to the [Autonity Contract Interface](https://docs.autonity.org/reference/api/aut/) section of the docs to keep docs `aut` usage in line with the current `aut` Release.

Changes made:

Aut Protocol function update:

- config: updated response structures
- getBlockPeriod: added `aut` command
- getEpochPeriod: added `aut` command
- getEpochFromBlock: added `aut` command
- getTreasuryAccount: added to docs, `aut` and rpc usage 
- getTreasuryFee - added `aut` and rpc usage examples
- setAccountabilityContract - added `aut` usage
- setACUContract: added `aut` usage
- setStabilizationContract: added `aut` usage
- setSupplyControlContract: added `aut` usage
- setOracleContract: added `aut` usage

Note no additions were made for the `aut protocol` commands to access public variables - `commission-rate-precision` and `last-epoch-block`. Commission rate precision is returned as part of `config` and last epoch block is returned by `get-last-epoch-block`.

Also:

- commented out text removed to keep docs clean.
closes #141  

