### PR TITLE
Edit validator reactivation for issue #143

### DIFF
--- a/content/docs/concepts/validator/_index.md
+++ b/content/docs/concepts/validator/_index.md
@@ -312,7 +312,7 @@ The process is:
 
 - The validator operator entity submits an activate request transaction to the Autonity Protocol Public APIs, calling the [`activateValidator()`](/reference/api/aut/#activatevalidator) function, submitting the transaction from the account used to register the validator (validator `treasury` account) and passing in the validator identifier address.
 - Transaction processed and committed to state:
-   - The validator's state is changed from `paused` to `active`.
+   - The validator's state is changed from its inactive state (`paused` or `jailed`) to `active`.
    - An `ActivatedValidator` event is emitted detailing: validator operator entity treasury address, validator identifier address, effective block height at which re-activation takes effect: projected block number for epoch end.
 
 The validator is active, able to accept new stake delegations, and once again eligible for selection to the consensus committee.

--- a/content/docs/reference/api/aut/_index.md
+++ b/content/docs/reference/api/aut/_index.md
@@ -1171,7 +1171,7 @@ Returns a `Validator` object consisting of:
 | `totalSlashed` | `uint256` | the total amount of stake that a validator has had slashed for accountability and omission faults since registration |
 | `jailReleaseBlock` | `uint256` | the block number at which a validator jail period applied for an accountability or omission fault ends (the validator can be re-activated after this block height) |
 | `provableFaultCount` | `uint256` | a counter of the number of times that a validator has been penalised for accountability and omission faults since registration |
-| `ValidatorState` | `state` | the state of the validator. `ValidatorState` is an enumerated type with enumerations: `active`, `paused`, `jailed` |
+| `ValidatorState` | `state` | the state of the validator. `ValidatorState` is an enumerated type with enumerations: `0`: active, `1`: paused, `2`: jailed |
 
 ### Usage
 

--- a/content/docs/validators/pause-vali/_index.md
+++ b/content/docs/validators/pause-vali/_index.md
@@ -20,7 +20,7 @@ Note that the pause and reactivation of a validator will become effective at the
 
 ## Pause as a validator
 
-1. To pause a validator from active to a paused, inactive state, use the `validator` command `pause`. Specify:
+1. To pause a validator from an `active` to a `paused`, inactive state, use the `validator` command `pause`. Specify:
 
 	- `--validator`: `<VALIDATOR_IDENTIFIER_ADDRESS>` of the validator node you are pausing.
 
@@ -65,7 +65,7 @@ Note that the pause and reactivation of a validator will become effective at the
 
 ## Re-activate a validator
 
-1. To resume a validator from a paused to an active state, use the `validator` command `activate`. Specify:
+1. To resume a validator from an inactive state (`paused` or `jailed`) to an `active` state, use the `validator` command `activate`. Specify:
 
 	- `--validator`: `<VALIDATOR_IDENTIFIER_ADDRESS>` of the validator node you are pausing.
 


### PR DESCRIPTION
A PR to improve consistency of wording in the Validators pages relevant to validator pausing,  for issue #143  and issue #145:

- Validator Concept page, Validator re-activation
- Validator Guide page, Pause and Reactivate a Validator

The rewording changes "paused to an active state" to "inactive state (paused or jailed) to an active state", which is used elsewhere.

closes #143 

Reference, Interfaces, Autonity Contract Interface:  `getValidator` method: update Response sub-section `validatorState` enumerations to correct and show the numeric value returned:  "enumerations: `0`: active, `1`: paused, `2`: jailed"

closes #145 