### PR TITLE
Patch:  Concepts: Consensus, Protocol AssetsAdd sub-page index

### DIFF
--- a/concepts/consensus/index.md
+++ b/concepts/consensus/index.md
@@ -3,6 +3,12 @@
 title: "Consensus "
 description: >
   Consensus mechanism - overview, core concepts and features
+listing:
+  type: table
+  fields: [title, description]
+  categories: false
+  filter-ui: false
+  sort-ui: false
 ---
 
 ## Overview

--- a/concepts/protocol-assets/index.md
+++ b/concepts/protocol-assets/index.md
@@ -3,6 +3,12 @@
 title: "Protocol assets "
 description: >
   Protocol assets - Auton, Newton, and Liquid Newton
+listing:
+  type: table
+  fields: [title, description]
+  categories: false
+  filter-ui: false
+  sort-ui: false
 ---
 
 Autonity has two native coins: the _Auton_ and the _Newton_. Auton is the utility coin used by transaction senders for paying gas fees within the autonity protocol and newton is the coin used for staking the network. Autonity implements a liquid staking model and on staking newton to the network a validator-specific _Liquid Newton_ token is minted to the staker.


### PR DESCRIPTION
A patch PR to restore to the Concepts section Consensus and Protocol Assets section top-level index page a listing of sub pages in the section.

This is simply adding to the top-level index page YML metadata section a `listing` directive:

```yml
listing:
  type: table
  fields: [title, description]
  categories: false
  filter-ui: false
  sort-ui: false
```
