### PR TITLE
Guide Autonity Oracle Server, Install and Run: editorial and corrections to Docker usage

### DIFF
--- a/oracle/install-oracle/index.md
+++ b/oracle/install-oracle/index.md
@@ -161,6 +161,7 @@ sudo systemctl restart docker
 :::
 
 1. Create a working directory and CD to your working directory:
+    
     ```bash
     mkdir autonity-oracle && cd autonity-oracle
     ```

--- a/oracle/install-oracle/index.md
+++ b/oracle/install-oracle/index.md
@@ -181,8 +181,6 @@ sudo systemctl restart docker
     ```
 
    (where `latest` can be replaced with another version)
-   
-   Note that the data source plugins are included as part of the Docker image at the directory path `/usr/local/bin/plugins`.
 
    ::: {.callout-note title="Note" collapse="false"}
    For more information on using and pulling Docker images from GHCR, see GitHub docs [Working with the container registry](https://docs.github.com/en/packages/working-with-a-github-packages-registry/working-with-the-container-registry).
@@ -198,26 +196,8 @@ sudo systemctl restart docker
     ghcr.io/autonity/autonity                latest    sha256:0eb561ce19ed3617038b022db89586f40abb9580cb0c4cd5f28a7ce74728a3d4   3375da450343   3 weeks ago    51.7MB
     ```
 -->
-<!-- TODO: UPDATE to autonity-oracle
 
-You can verify the setup of the image and version using Docker:
-
-```bash
-$ docker run --rm ghcr.io/autonity/autonity-oracle:latest version
-```
-```
-Autonity
-Version: 0.10.1
-Architecture: amd64
-Protocol Versions: [66]
-Go Version: go1.17.10
-Operating System: linux
-GOPATH=
-GOROOT=/usr/local/go
-```
--->
-
-(Optional) Add data source plugins. Navigate to the plugins sub-directory of your working directory and add sub-directories for additional plugins you are installing.
+3. Data source plugins. Note that the data source plugins are included as part of the Docker image at the directory path `/usr/local/bin/plugins`.
 
 ::: {.callout-note title="Info" collapse="false"}
 You can now [configure and launch oracle server](/oracle/run-oracle/#run-docker).
@@ -257,14 +237,19 @@ A basic set of data adaptor plugins for sourcing this data is provided out the b
 - Forex plugins: for connecting to public FX data sources. See the `forex_` prefixed adaptors in [`/plugins`](https://github.com/autonity/autonity-oracle/tree/master/plugins). Four forex plugins are currently provided.
 - ATN and NTN plugins:
   - For connecting to Piccadilly Testnet. See the `pcgc_cax` adaptor in [`/plugins`](https://github.com/autonity/autonity-oracle/tree/master/plugins). This provides ATN and NTN data from the Centralized Auton Exchange deployed to Piccadilly for the Piccadilly Circus Games Competition. See [game.autonity.org](https:game.autonity.org).
-  - For connecting to Bakerloo Testnet. See the `sim_plugin` adaptor in [`/plugins`](https://github.com/autonity/autonity-oracle/tree/master/plugins/simulator_plugin). This provides simulated ATN and NTN data. 
+  - For connecting to Bakerloo Testnet. See the `sim_plugin` adaptor in [`/plugins`](https://github.com/autonity/autonity-oracle/tree/master/plugins/simulator_plugin). This provides simulated ATN and NTN data.
 
-The plugins are built by the `make` process when building from source. The plugins are included pre-built as part of oracle server Docker image and the pre-built executable.
 
-If installing by building from source, run the make command appropriate for the Testnet you are connecting to as described in [Build from source code](/oracle/install-oracle/#install-source). You can view the built plugins in the directory `./build/bin/plugins`. 
+**These out the box plugins are built and included by default according to the installation method and Autonity testnet chosen.** They are:
+
+- Built by the `make` process when building from source. Run the make command appropriate for the Testnet you are connecting to as described in [Build from source code](/oracle/install-oracle/#install-source). You can view the built plugins in the directory `./build/bin/plugins`.
+
+- Included pre-built as part of the pre-built executable.  You can view the built plugins in the directory `/plugins`. The executable is built for Piccadilly Testnet only.
+
+- Included pre-built as part of oracle server Docker image and the pre-built executable. Install the Docker image for the Testnet you are connecting to as described in [Installing the Docker image](/oracle/install-oracle/#install-docker). The built plugins are included in the Docker container at the path `/usr/local/bin/plugins`.
 
 ::: {.callout-note title="Note" collapse="false"}
-The Simulator plugin is built when building from source for Bakerloo Testnet. You can also build the Simulator plugin independently by running the command `make simulator`. This will build the `sim_plugin` in the `/plugins` directory. A local testnet could be a scenario for setting up and using a simulator.
+The Simulator plugin for simulated ATN and NTN price data is built when building from source for Bakerloo Testnet. You can also build the Simulator plugin independently by running the command `make simulator`. This will build the `sim_plugin` in the `/plugins` directory. A local testnet could be a scenario for setting up and using a simulator.
 
 If you have developed your own plugins for external data sources using the oracle server's plugin template architecture, then you will need to build them and add to the `/plugins` directory.
 

--- a/oracle/install-oracle/index.md
+++ b/oracle/install-oracle/index.md
@@ -234,10 +234,10 @@ $ ./autoracle version
 v0.1.6
 ```
 
-If using Docker, the setup of the Bakerloo image can be verified with:
+If using Docker, the setup of the Piccadilly Testnet image can be verified with:
 
 ```bash
-docker run --rm ghcr.io/autonity/autonity-oracle:latest version 
+docker run --rm ghcr.io/autonity/autonity-oracle-piccadilly:latest version 
 ```
 ```
 v0.1.6

--- a/oracle/run-oracle/index.md
+++ b/oracle/run-oracle/index.md
@@ -182,7 +182,7 @@ The oracle server config file `oracle-server.config` can be found in the `/auton
    key.password 123%&%^$
    log.level 3
    ws ws://127.0.0.1:8546
-   plugin.dir ./build/binplugins
+   plugin.dir ./build/bin/plugins
    plugin.conf ./config/plugins-conf.yml
    ```
    
@@ -230,11 +230,12 @@ For example, to start oracle server specifying command line flags when running t
    - `<PWD>` is the password to your oracle server key file
    - `<WS_ADDRESS>` is the WebSocket IP Address of your connected Autonity Go Client node, e.g. "ws://172.17.0.2:8546", see [install Autonity, networks](/node-operators/install-aut/#network)). 
    
-   ::: {.callout-note title="Note" collapse="false"}
-   - Note that all flags after the image name are passed to the Autonity Oracle Server in the container, and thus follow the same pattern as for [running a binary or source install](#run-binary)
-   - The command above creates a temporary container, which is deleted (via the `--rm` flag) when the node is shut down.
-   - The `--volume` flags are needed to mount the key and config files. The plugins are pre-built and included in the Docker container at the path `/usr/local/bin/plugins/`.
-   :::
+::: {.callout-note title="Note" collapse="false"}
+
+- Note that all flags after the image name are passed to the Autonity Oracle Server in the container, and thus follow the same pattern as for [running a binary or source install](#run-binary)
+- The command above creates a temporary container, which is deleted (via the `--rm` flag) when the node is shut down.
+- The `--volume` flags are needed to mount the key and config files. The plugins are pre-built and included in the Docker container at the path `/usr/local/bin/plugins/`.
+:::
 
    See the [Autonity Oracle Server command-line reference](/reference/cli/oracle/) or the oracle server's GitHub repo [README, Configuration of oracle server](https://github.com/autonity/autonity-oracle?tab=readme-ov-file#configuration-of-oracle-server) section [CLI flags](https://github.com/autonity/autonity-oracle?tab=readme-ov-file#cli-flags) for the full set of available flags.
 

--- a/oracle/run-oracle/index.md
+++ b/oracle/run-oracle/index.md
@@ -48,7 +48,6 @@ Transaction costs for submitting price report data on-chain _are_ refunded but t
    
 5. Start oracle server:
 
-
     ``` bash
     ./autoracle --config="./oracle-server.config"
     ```
@@ -112,12 +111,12 @@ If plugins for external data sources or the symbols for which oracle server prov
    ```bash
    docker run \
         -t -i \
-        --volume $<ORACLE_KEYFILE>:/autoracle/oracle.key \
-        --volume $<PLUGINS_CONF_FILE>:/autoracle/plugins-conf.yml \
-        --volume $<ORACLE_SERVER_CONF_FILE>:/autoracle/oracle-server.config \
+        --volume ./<ORACLE_KEYFILE>:/autoracle/oracle.key \
+        --volume ./<PLUGINS_CONF_FILE>:/autoracle/plugins-conf.yml \
+        --volume ./<ORACLE_SERVER_CONF_FILE>:/autoracle/oracle-server.config \
         --name <ORACLE_CONTAINER_NAME> \
-        --rm \
-        <DOCKER_IMAGE>:latest \
+        --rm <DOCKER_IMAGE>:latest \
+        --config="/autoracle/oracle-server.config" \
         ;
    ```
 
@@ -147,16 +146,15 @@ If plugins for external data sources or the symbols for which oracle server prov
 5. Start oracle server. On running the Docker you should see something like:
 
    ```
- 	2023/09/26 10:04:53 
+ 	2024/03/06 11:44:45
 
-        Running autonity oracle server v0.1.2
-        with symbols: AUD-USD,CAD-USD,EUR-USD,GBP-USD,JPY-USD,SEK-USD,ATN-USD,NTN-USD,NTN-ATN
-        and plugin directory: ./build/bin/plugins/
-        by connecting to L1 node: ws://127.0.0.1:8546
-        on oracle contract address: 0x47e9Fbef8C83A1714F1951F142132E6e90F5fa5D 
-   ```
+ 	Running autonity oracle server v0.1.6
+	with plugin directory: /usr/local/bin/plugins/
+ 	by connecting to L1 node: ws://127.0.0.1:8546
+ 	on oracle contract address: 0x47e9Fbef8C83A1714F1951F142132E6e90F5fa5D
+ 	```
    
-   Oracle server will connect to external data sources using the providers set in the `plugin.` configuration properties and begin submitting price reports to the connected node.
+   Oracle server will discover plugins in the `plugins` configuration, set them up, connect to external data sources using the providers set in the `plugins-conf.yml` configuration properties, and begin submitting price reports to the connected node.
 
 
 ## Configure oracle server
@@ -174,7 +172,7 @@ The oracle server config file `oracle-server.config` can be found in the `/auton
    - `plugin.dir` is the path to the directory containing the built data plugins.
    - `plugin.conf` is the path to the plugins YAML configuration file `plugins-conf.yml` (defaults to `./plugins-conf.yml`).
 
-   An example configuration could be:
+   An example configuration for an oracle server binary could be:
 
    ```
    tip 1
@@ -185,7 +183,19 @@ The oracle server config file `oracle-server.config` can be found in the `/auton
    plugin.dir ./build/bin/plugins
    plugin.conf ./config/plugins-conf.yml
    ```
-   
+  
+   An example configuration for an oracle server Docker image could be per beneath. Note the mounted path is used for `key.file` and `plugin.conf` files. A mounted path is not used for the `plugin.dir` config which takes the Docker image plugins directory path `/usr/local/bin/plugins/`:
+
+   ```
+   tip 1
+   key.file /autoracle/UTC--2023-02-27T09-10-19.592765887Z--b749d3d83376276ab4ddef2d9300fb5>
+   key.password 123%&%^$
+   log.level 3
+   ws ws://127.0.0.1:8546
+   plugin.dir /usr/local/bin/plugins/
+   plugin.conf /autoracle/plugins-conf.yml
+   ```
+ 
 ### Setup using command line flags or system env variables  
 The oracle server configuration can also be set directly in the terminal as console flags or as system environment variables.
 
@@ -207,8 +217,8 @@ For example, to start oracle server specifying command line flags when running t
    ```bash
    docker run \
         -t -i \
-        --volume $<ORACLE_KEYFILE>:/autoracle/oracle.key \
-        --volume $<PLUGINS_CONF_FILE>:/autoracle/plugins-conf.yml \
+        --volume ./<ORACLE_KEYFILE>:/autoracle/oracle.key \
+        --volume ./<PLUGINS_CONF_FILE>:/autoracle/plugins-conf.yml \
         --name <ORACLE_CONTAINER_NAME> \
         --rm \
         <DOCKER_IMAGE>:latest \


### PR DESCRIPTION
Edits and fixes to:

Install AOS:

- Clarify data plugin installation is out the box per testnet chosen and installation method
- Clarify Docker image installation

Run AOS:

- Correct Docker image run command - missing `--config` flag, correct mounted path usage, remove `$(pwd)` and correct with leading `./` to the file path
- General editorial to Docker entries throughout
- Correct formatting in `{.callout-note}` box in section https://docs.autonity.org/oracle/run-oracle/#setup-using-command-line-flags-or-system-env-variables.

With this PR the note box renders correctly.

closes #112 