### PR TITLE
add logic to scroll hash links into view

### DIFF
--- a/_templates/autonity-base.html
+++ b/_templates/autonity-base.html
@@ -34,7 +34,6 @@
     $endif$
     $math$
     $endif$
-
     $for(css)$
     <link rel="stylesheet" href="$css$" />
     $endfor$
@@ -65,5 +64,12 @@
     $endfor$
 
 </body>
-
+<script>
+window.addEventListener('load', () => {
+    const anchor = location.hash;
+    if (anchor && document.querySelector(anchor)) {
+        document.querySelector(anchor).scrollIntoView();
+    }
+});
+</script>
 </html>


### PR DESCRIPTION
Changelog:

_This PR fixes an issue where links directly to anchor tags would not scroll to that anchor tag, the user would load into the page at the top._