### PR TITLE
fix callout blocks syntax

### DIFF
--- a/account-holders/key-mgt/clef/index.md
+++ b/account-holders/key-mgt/clef/index.md
@@ -123,7 +123,7 @@ The password that you are setting here is not the password for your keystore. It
 
 ##  Submit transactions using NodeJS Console
 ::: {.callout-note title="Note" collapse="false"}
-Since you are using clef to sign transactions, whenever you issue a command on the NodeJS console which requires a signature from your private key, the nodejs console will hang. This is because it is waiting for the signature from clef, that you need to manually approve. This process can be automated using the clef rule engine https://geth.ethereum.org/docs/clef/tutorial#automatic-rules
+Since you are using clef to sign transactions, whenever you issue a command on the NodeJS console which requires a signature from your private key, the nodejs console will hang. This is because it is waiting for the signature from clef, that you need to manually approve. This process can be automated using the clef rule engine [https://geth.ethereum.org/docs/clef/tutorial#automatic-rules](https://geth.ethereum.org/docs/clef/tutorial#automatic-rules)
 :::
 
 1. Start the Autonity NodeJS Console and then, to view the accounts in Clef, enter as follows:

--- a/account-holders/key-mgt/clef/index.md
+++ b/account-holders/key-mgt/clef/index.md
@@ -122,7 +122,9 @@ The password that you are setting here is not the password for your keystore. It
 
 
 ##  Submit transactions using NodeJS Console
-::: {.callout-note title="Note" collapse="false"}Since you are using clef to sign transactions, whenever you issue a command on the NodeJS console which requires a signature from your private key, the nodejs console will hang. This is because it is waiting for the signature from clef, that you need to manually approve. This process can be automated using the clef rule engine https://geth.ethereum.org/docs/clef/tutorial#automatic-rules:::
+::: {.callout-note title="Note" collapse="false"}
+Since you are using clef to sign transactions, whenever you issue a command on the NodeJS console which requires a signature from your private key, the nodejs console will hang. This is because it is waiting for the signature from clef, that you need to manually approve. This process can be automated using the clef rule engine https://geth.ethereum.org/docs/clef/tutorial#automatic-rules
+:::
 
 1. Start the Autonity NodeJS Console and then, to view the accounts in Clef, enter as follows:
 

--- a/concepts/validator/index.md
+++ b/concepts/validator/index.md
@@ -59,7 +59,8 @@ The public key is used:
 - To verify the signature of consensus level network messages.
 - To derive an ethereum format account that is then used to identify the validator node. See [validator identifier](#validator-identifier).
 
-::: {.callout-note title="Note" collapse="false"}The private key can be used by Autonity’s `bootnode` utility to derive the hex string used in the `enode` URL. (See Networking Options  `nodekey` and `nodekeyhex` in [Autonity command-line options](/reference/cli/#usage) and, for reference,  the ethereum stack exchange article [how to produce enode from node key](https://ethereum.stackexchange.com/questions/28970/how-to-produce-enode-from-node-key).)
+::: {.callout-note title="Note" collapse="false"}
+The private key can be used by Autonity’s `bootnode` utility to derive the hex string used in the `enode` URL. (See Networking Options  `nodekey` and `nodekeyhex` in [Autonity command-line options](/reference/cli/#usage) and, for reference,  the ethereum stack exchange article [how to produce enode from node key](https://ethereum.stackexchange.com/questions/28970/how-to-produce-enode-from-node-key).)
 :::
 
 ### Validator enode URL

--- a/concepts/validator/index.md
+++ b/concepts/validator/index.md
@@ -59,8 +59,8 @@ The public key is used:
 - To verify the signature of consensus level network messages.
 - To derive an ethereum format account that is then used to identify the validator node. See [validator identifier](#validator-identifier).
 
-::: {.callout-note title="Note" collapse="false"}The private key can be used by Autonity’s `bootnode` utility to derive the hex string used in the `enode` URL. (See Networking Options  `nodekey` and `nodekeyhex` in [Autonity command-line options](/reference/cli/#usage) and, for reference,  the ethereum stack exchange article [how to produce enode from node key](https://ethereum.stackexchange.com/questions/28970/how-to-produce-enode-from-node-key).):::
-
+::: {.callout-note title="Note" collapse="false"}The private key can be used by Autonity’s `bootnode` utility to derive the hex string used in the `enode` URL. (See Networking Options  `nodekey` and `nodekeyhex` in [Autonity command-line options](/reference/cli/#usage) and, for reference,  the ethereum stack exchange article [how to produce enode from node key](https://ethereum.stackexchange.com/questions/28970/how-to-produce-enode-from-node-key).)
+:::
 
 ### Validator enode URL
 The `enode` URL is the network address of the peer node operated by the validator. It provides the network location of the node client for p2p networking.

--- a/delegators/transfer-lntn/index.md
+++ b/delegators/transfer-lntn/index.md
@@ -84,7 +84,9 @@ Before transferring LNTN, verify your liquid newton holdings and the liquid newt
     0x0aee457755874ff776e36ec2d76955fcd4856d6753d5e75e1ba125d029c67725
     ```
 
-::: {.callout-note title="Note" collapse="false"}The Liquid Newton contract is ERC20 so you can also transfer LNTN using the ERC20 `transfer` command in the `token` command group.
+::: {.callout-note title="Note" collapse="false"}
+The Liquid Newton contract is ERC20 so you can also transfer LNTN using the ERC20 `transfer` command in the `token` command group.
+:::
 
 If using `transfer`, pass in as arguments:
 
@@ -95,4 +97,3 @@ If using `transfer`, pass in as arguments:
     ```bash
     aut token transfer --token <LIQUID_CONTRACT>  <RECIPIENT_ACCOUNT_ADDRESS> <AMOUNT>  | aut tx sign - | aut tx send -
     ```
-:::

--- a/reference/genesis/index.md
+++ b/reference/genesis/index.md
@@ -84,7 +84,8 @@ Genesis configuration file JSON objects:
 #### config.autonity object
 
 ::: {.callout-note title="Note" collapse="false"}
-In current state the `operator` governance account is an EOA. It could be assigned to a smart contract address. For example, in the case the blockchain is DAO-governed.:::
+In current state the `operator` governance account is an EOA. It could be assigned to a smart contract address. For example, in the case the blockchain is DAO-governed.
+:::
 
 |Parameter|Description|Value|
 |---------|-----------|-----|


### PR DESCRIPTION
some sections in the documentation have syntax callout blocks that are not closed. This can cause confusion for the reader and needs to be corrected to ensure good readability and understanding. #171 