### PR TITLE
update styling to break code tag when limit reached

### DIFF
--- a/_assets/css/styles.css
+++ b/_assets/css/styles.css
@@ -539,3 +539,7 @@ span.resource {
     background-color: #000000;
     color: #fff;
 }
+
+code {
+    word-break: break-all;
+}

--- a/_assets/css/styles.css
+++ b/_assets/css/styles.css
@@ -539,7 +539,10 @@ span.resource {
     background-color: #000000;
     color: #fff;
 }
+.content, .content * {
+    overflow-wrap: break-word;
+}
 
-code {
+td, td * {
     word-break: break-all;
 }


### PR DESCRIPTION
_Changelog_

Added `overflow-wrap` to the content container and all children, this ensures that all text within elements of the .content class, including nested elements. break on the boundary of the container.

Because tables will render based on their content size (and "break" out of the contaier), i've applied `word-break: break-all` to the cell level and their children. This is used to ensure that even words or strings without breaks can wrap within the confines of table cells, thus maintaining the integrity and layout of table structures.

### Rendered Test case
![image](https://github.com/autonity/docs.autonity.org/assets/5268627/6d70297d-1d29-47a0-a8ad-ea0acfff99e7)

Styling updates, fixes [this](https://github.com/autonity/docs.autonity.org/issues/180) issue