### PR TITLE
Node operators - edit install docker to add Bakerloo docker image

### DIFF
--- a/node-operators/install-aut/index.md
+++ b/node-operators/install-aut/index.md
@@ -195,7 +195,16 @@ sudo systemctl restart docker
 ```
 :::
 
-1. Pull the Autonity Go Client image from the Github Container Registry:
+1. Pull the Autonity Go Client image from the Github Container Registry.
+
+   If you are deploying to the Bakerloo Testnet:
+   
+    ```bash
+    docker pull ghcr.io/autonity/autonity-bakerloo:latest
+    ```
+
+   If you are deploying to the Piccadilly Testnet:
+   
     ```bash
     docker pull ghcr.io/autonity/autonity:latest
     ```


### PR DESCRIPTION
Update to the install docker image guide:

- `Node operators, Install Autonity in your environment, Installing the Docker image`: edit for Bakerloo-specific Docker image