### PR TITLE
Update Autonity Contract Interface `aut` usage and examples for `aut v0.5.0` Release

### DIFF
--- a/reference/api/aut/index.md
+++ b/reference/api/aut/index.md
@@ -720,7 +720,7 @@ None.
 ## aut
 
 ``` {.aut}
-aut protocol get-block-period [OPTIONS]
+aut protocol block-period [OPTIONS]
 ```
 ## RPC
 
@@ -736,7 +736,7 @@ aut protocol get-block-period [OPTIONS]
 ## aut
 
 ``` {.aut}
-aut protocol get-block-period --rpc-endpoint https://rpc1.piccadilly.autonity.org
+aut protocol block-period --rpc-endpoint https://rpc1.piccadilly.autonity.org
 1
 ```
 ## RPC
@@ -776,7 +776,7 @@ Returns a `committee` array of `CommitteeMember` objects, each object consisting
 ## aut
 
 ``` {.aut}
-aut protocol get-committee [OPTIONS]
+aut protocol committee [OPTIONS]
 ```
 ## RPC
 
@@ -793,7 +793,7 @@ aut protocol get-committee [OPTIONS]
 ## aut
 
 ``` {.aut}
-aut protocol get-committee -r https://rpc1.bakerloo.autonity.org
+aut protocol committee -r https://rpc1.bakerloo.autonity.org
 [
   {
     "address": "0xBaf935b88066021a0B0BD34cEB2Ba10389b6Aa0D",
@@ -855,7 +855,7 @@ Returns a `committeeNodes` list of committee member enode URL addresses consisti
 ## aut
 
 ``` {.aut}
-aut protocol get-committee-enodes [OPTIONS]
+aut protocol committee-enodes [OPTIONS]
 ```
 ## RPC
 
@@ -871,7 +871,7 @@ aut protocol get-committee-enodes [OPTIONS]
 ## aut
 
 ``` {.aut}
-aut protocol get-committee-enodes -r https://rpc1.bakerloo.autonity.org
+aut protocol committee-enodes -r https://rpc1.bakerloo.autonity.org
 ['enode://181dd52828614267b2e3fe16e55721ce4ee428a303b89a0cba3343081be540f28a667c9391024718e45ae880088bd8b6578e82d395e43af261d18cedac7f51c3@35.246.21.247:30303', 'enode://e3b8ea9ddef567225530bcbae68af5d46f59a2b39acc04113165eba2744f6759493027237681f10911d4c12eda729c367f8e64dfd4789c508b7619080bb0861b@35.189.64.207:30303', 'enode://00c6c1704c103e74a26ad072aa680d82f6c677106db413f0afa41a84b5c3ab3b0827ea1a54511f637350e4e31d8a87fdbab5d918e492d21bea0a399399a9a7b5@34.105.163.137:30303', 'enode://dffaa985bf36c8e961b9aa7bcdd644f1ad80e07d7977ce8238ac126d4425509d98da8c7f32a3e47e19822bd412ffa705c4488ce49d8b1769b8c81ee7bf102249@35.177.8.113:30308', 'enode://1bd367bfb421eb4d21f9ace33f9c3c26cd1f6b257cc4a1af640c9af56f338d865c8e5480c7ee74d5881647ef6f71d880104690936b72fdc905886e9594e976d1@35.179.46.181:30309', 'enode://a7465d99513715ece132504e47867f88bb5e289b8bca0fca118076b5c733d901305db68d1104ab838cf6be270b7bf71e576a44644d02f8576a4d43de8aeba1ab@3.9.98.39:30310', 'enode://c6ae16b58cf2e073649ec34ed59550c57389fcb949f51b806d6f7de26e7961cfc33794fde67b484ce9966a30e5ab5331c610b1b659249a6d66cc9e6d8a3d23d1@143.198.240.242:30303', 'enode://06facaec377a55fe8fd9e30cc922bedc7ee97e292294435635fa3b053c30215b87954daa27c79a73e3a5013124318b084907c81f518bcf36f88dad4d01e952ec@138.68.118.4:30303', 'enode://0c71d8076f0543505aae22901471d5437f1fd92b3d154d154edcec5baf0d7b121e6e8dc85ae725daf77cbc50ff5616727d59d36c2606751401000580e155e2bc@5.181.104.29:30303']
 ```
 
@@ -906,7 +906,7 @@ Returns the unique identifier of the epoch block epoch associated with a block a
 ## aut
 
 ``` {.aut}
-aut protocol get-epoch-from-block [OPTIONS] BLOCK
+aut protocol epoch-from-block [OPTIONS] BLOCK
 ```
 
 ## RPC
@@ -923,7 +923,7 @@ aut protocol get-epoch-from-block [OPTIONS] BLOCK
 ## aut
 
 ``` {.aut}
-aut protocol get-epoch-from-block --rpc-endpoint https://rpc1.piccadilly.autonity.org 3293857
+aut protocol epoch-from-block --rpc-endpoint https://rpc1.piccadilly.autonity.org 3293857
 1829
 ```
 
@@ -963,7 +963,7 @@ None.
 ## aut
 
 ``` {.aut}
-aut protocol get-epoch-period [OPTIONS]
+aut protocol epoch-period [OPTIONS]
 ```
 ## RPC
 
@@ -979,7 +979,7 @@ aut protocol get-epoch-period [OPTIONS]
 ## aut
 
 ``` {.aut}
-aut protocol get-epoch-period --rpc-endpoint https://rpc1.piccadilly.autonity.org
+aut protocol epoch-period --rpc-endpoint https://rpc1.piccadilly.autonity.org
 1800
 ```
 ## RPC
@@ -1008,7 +1008,7 @@ Returns the number of the last block in the preceding epoch at the block height 
 ## aut
 
 ``` {.aut}
-aut protocol get-last-epoch-block [OPTIONS]
+aut protocol last-epoch-block [OPTIONS]
 ```
 
 ## RPC
@@ -1024,7 +1024,7 @@ aut protocol get-last-epoch-block [OPTIONS]
 ## aut
 
 ``` {.aut}
-aut protocol get-last-epoch-block -r https://rpc1.piccadilly.autonity.org
+aut protocol last-epoch-block -r https://rpc1.piccadilly.autonity.org
 12981684
 ```
 ## RPC
@@ -1058,7 +1058,7 @@ None.
 ## aut
 
 ``` {.aut}
-aut protocol get-max-committee-size [OPTIONS]
+aut protocol max-committee-size [OPTIONS]
 ```
 ## RPC
 
@@ -1074,7 +1074,7 @@ aut protocol get-max-committee-size [OPTIONS]
 ## aut
 
 ``` {.aut}
-aut protocol get-max-committee-size --rpc-endpoint https://rpc1.bakerloo.autonity.org/
+aut protocol max-committee-size --rpc-endpoint https://rpc1.bakerloo.autonity.org/
 50
 ```
 ## RPC
@@ -1114,7 +1114,7 @@ None.
 ## aut
 
 ``` {.aut}
-aut protocol get-minimum-base-fee [OPTIONS]
+aut protocol minimum-base-fee [OPTIONS]
 ```
 ## RPC
 
@@ -1130,7 +1130,7 @@ aut protocol get-minimum-base-fee [OPTIONS]
 ## aut
 
 ``` {.aut}
-aut protocol get-minimum-base-fee --rpc-endpoint https://rpc1.bakerloo.autonity.org/
+aut protocol minimum-base-fee --rpc-endpoint https://rpc1.bakerloo.autonity.org/
 500000000
 ```
 ## RPC
@@ -1222,7 +1222,7 @@ None.
 ## aut
 
 ``` {.aut}
-aut protocol get-operator [OPTIONS]
+aut protocol operator [OPTIONS]
 ```
 
 ## RPC
@@ -1239,7 +1239,7 @@ aut protocol get-operator [OPTIONS]
 ## aut
 
 ``` {.aut}
-aut protocol get-operator -r https://rpc1.bakerloo.autonity.org/
+aut protocol operator -r https://rpc1.bakerloo.autonity.org/
 0x293039dDC627B1dF9562380c0E5377848F94325A
 ```
 ## RPC
@@ -1312,7 +1312,7 @@ The proposer is selected from the committee via weighted random sampling, with s
 ## aut
 
 ``` {.aut}
-aut protocol get-proposer [OPTIONS] HEIGHT ROUND
+aut protocol proposer [OPTIONS] HEIGHT ROUND
 ```
 ## RPC
 
@@ -1328,7 +1328,7 @@ aut protocol get-proposer [OPTIONS] HEIGHT ROUND
 ## aut
 
 ``` {.aut}
-aut protocol get-proposer -r https://rpc1.bakerloo.autonity.org/ 4576868 0
+aut protocol proposer -r https://rpc1.bakerloo.autonity.org/ 4576868 0
 0x0c7dC2aB00c7b5934EDA097a8585f56367A94dA4
 ```
 ## RPC
@@ -1367,7 +1367,7 @@ None.
 ## aut
 
 ``` {.aut}
-aut protocol get-treasury-account [OPTIONS]
+aut protocol treasury-account [OPTIONS]
 ```
 ## RPC
 
@@ -1382,7 +1382,7 @@ aut protocol get-treasury-account [OPTIONS]
 ## aut
 
 ``` {.aut}
-aut protocol get-treasury-account -r https://rpc1.piccadilly.autonity.org/
+aut protocol treasury-account -r https://rpc1.piccadilly.autonity.org/
 0xF74c34Fed10cD9518293634C6f7C12638a808Ad5
 ```
 ## RPC
@@ -1414,7 +1414,7 @@ None.
 ## aut
 
 ``` {.aut}
-aut protocol get-treasury-fee [OPTIONS]
+aut protocol treasury-fee [OPTIONS]
 ```
 ## RPC
 
@@ -1429,7 +1429,7 @@ aut protocol get-treasury-fee [OPTIONS]
 ## aut
 
 ``` {.aut}
-aut protocol get-treasury-fee -r https://rpc1.piccadilly.autonity.org/
+aut protocol treasury-fee -r https://rpc1.piccadilly.autonity.org/
 10000000000000000
 ```
 ## RPC
@@ -1461,7 +1461,7 @@ None.
 ## aut
 
 ``` {.aut}
-aut protocol get-unbonding-period [OPTIONS]
+aut protocol unbonding-period [OPTIONS]
 ```
 ## RPC
 
@@ -1477,7 +1477,7 @@ aut protocol get-unbonding-period [OPTIONS]
 ## aut
 
 ``` {.aut}
-aut protocol get-unbonding-period -r https://rpc1.piccadilly.autonity.org/
+aut protocol unbonding-period -r https://rpc1.piccadilly.autonity.org/
 21600
 ```
 ## RPC
@@ -1639,7 +1639,7 @@ aut validator list [OPTIONS]
 
 
 ::: {.callout-note title="Note" collapse="false"}
-`getValidators` can also be called using the `aut` command `aut protocol get-validators`.
+`getValidators` can also be called using the `aut` command `aut protocol validators`.
 :::
 
 ### Example
@@ -1710,7 +1710,7 @@ None.
 ## aut
 
 ``` {.aut}
-aut protocol get-version [OPTIONS]
+aut protocol version [OPTIONS]
 ```
 ## RPC
 
@@ -1726,7 +1726,7 @@ aut protocol get-version [OPTIONS]
 ## aut
 
 ``` {.aut}
-aut protocol get-version -r https://rpc1.piccadilly.autonity.org/8545/
+aut protocol version -r https://rpc1.piccadilly.autonity.org/8545/
 1
 ```
 ## RPC

--- a/reference/api/aut/op-prot/index.md
+++ b/reference/api/aut/op-prot/index.md
@@ -37,7 +37,7 @@ On a successful call the function emits a `BurnedStake` event, logging: `_addr`,
 ::: {.panel-tabset}
 ## aut
 ``` {.aut}
-aut protocol burn [OPTIONS] AMOUNT ACCOUNT
+aut governance burn [OPTIONS] AMOUNT ACCOUNT
 ```
 :::
 
@@ -46,7 +46,7 @@ aut protocol burn [OPTIONS] AMOUNT ACCOUNT
 ::: {.panel-tabset}
 ## aut
 ``` {.aut}
-aut protocol burn 1 0xd4eddde5d1d0d7129a7f9c35ec55254f43b8e6d4 | aut tx sign - | aut tx send -
+aut governance burn 1 0xd4eddde5d1d0d7129a7f9c35ec55254f43b8e6d4 | aut tx sign - | aut tx send -
 (consider using 'KEYFILEPWD' env var).
 Enter passphrase (or CTRL-d to exit): 
 0x3e86062cca9fa263acb7076f8287117e9ee2c5570e0f4e4bd2ff4db21895796e
@@ -82,7 +82,7 @@ On a successful call the function emits a `MintedStake` event, logging: `_addr`,
 ::: {.panel-tabset}
 ## aut
 ``` {.aut}
-aut protocol mint [OPTIONS] AMOUNT RECIPIENT
+aut governance mint [OPTIONS] AMOUNT RECIPIENT
 ```
 :::
 
@@ -91,7 +91,7 @@ aut protocol mint [OPTIONS] AMOUNT RECIPIENT
 ::: {.panel-tabset}
 ## aut
 ``` {.aut}
-aut protocol mint 1 0xd4eddde5d1d0d7129a7f9c35ec55254f43b8e6d4 | aut tx sign - | aut tx send -
+aut governance mint 1 0xd4eddde5d1d0d7129a7f9c35ec55254f43b8e6d4 | aut tx sign - | aut tx send -
 (consider using 'KEYFILEPWD' env var).
 Enter passphrase (or CTRL-d to exit): 
 0xbd9e604372cc922c4594b0fce94919f933734e29b0043c5af3c4a7774ed99ad7
@@ -188,7 +188,7 @@ None.
 ## aut
 
 ``` {.aut}
-aut protocol set-accountability-contract [OPTIONS] CONTRACT-ADDRESS
+aut governance set-accountability-contract [OPTIONS] CONTRACT-ADDRESS
 ```
 :::
 
@@ -218,7 +218,7 @@ None.
 ## aut
 
 ``` {.aut}
-aut protocol set-acu-contract [OPTIONS] CONTRACT-ADDRESS
+aut governance set-acu-contract [OPTIONS] CONTRACT-ADDRESS
 ```
 :::
 
@@ -245,7 +245,7 @@ The updated parameter can be retrieved from state by calling the [`getMaxCommitt
 ## aut
 
 ``` {.aut}
-aut protocol set-committee-size [OPTIONS] COMMITTEE_SIZE
+aut governance set-committee-size [OPTIONS] COMMITTEE_SIZE
 ```
 :::
 
@@ -255,7 +255,7 @@ aut protocol set-committee-size [OPTIONS] COMMITTEE_SIZE
 ## aut
 
 ``` {.aut}
-$ aut protocol set-committee-size 50 | aut tx sign - | aut tx send -
+$ aut governance set-committee-size 50 | aut tx sign - | aut tx send -
 (consider using 'KEYFILEPWD' env var).
 Enter passphrase (or CTRL-d to exit): 
 0x3dbe5afbb89267b1549f735d09ac3acd6a4894eccbab8dca125497806c8fdc2d
@@ -295,7 +295,7 @@ On a successful call the function emits an `EpochPeriodUpdated` event, logging: 
 ## aut
 
 ``` {.aut}
-aut protocol set-epoch-period [OPTIONS] EPOCH_PERIOD
+aut governance set-epoch-period [OPTIONS] EPOCH_PERIOD
 ```
 :::
 
@@ -305,7 +305,7 @@ aut protocol set-epoch-period [OPTIONS] EPOCH_PERIOD
 ## aut
 
 ``` {.aut}
-aut protocol set-epoch-period 1000 | aut tx sign - | aut tx send -
+aut governance set-epoch-period 1000 | aut tx sign - | aut tx send -
 (consider using 'KEYFILEPWD' env var).
 Enter passphrase (or CTRL-d to exit): 
 0xdf3b3eb316a3070a591621d8cc450ca6d1af3a6d57a0455714b5bff72eb06b92
@@ -430,7 +430,7 @@ On a successful call the function emits a `MinimumBaseFeeUpdated` event, logging
 ## aut
 
 ``` {.aut}
-aut protocol set-minimum-base-fee [OPTIONS] base-fee
+aut governance set-minimum-base-fee [OPTIONS] base-fee
 ```
 :::
 
@@ -440,7 +440,7 @@ aut protocol set-minimum-base-fee [OPTIONS] base-fee
 ## aut
 
 ``` {.aut}
-aut protocol set-minimum-base-fee 50000000 | aut tx sign - | aut tx send -
+aut governance set-minimum-base-fee 50000000 | aut tx sign - | aut tx send -
 (consider using 'KEYFILEPWD' env var).
 Enter passphrase (or CTRL-d to exit): 
 0x4d1abc6881f63d7856b3b2d6f0b9865a4a9c2b1378dd824e36e9ac194fd8da52
@@ -478,7 +478,7 @@ The updated parameter can be retrieved from state by a call to the [`operatorAcc
 ## aut
 
 ``` {.aut}
-aut protocol set-operator-account [OPTIONS] OPERATOR-ADDRESS
+aut governance set-operator-account [OPTIONS] OPERATOR-ADDRESS
 ```
 :::
 
@@ -488,7 +488,7 @@ aut protocol set-operator-account [OPTIONS] OPERATOR-ADDRESS
 ## aut
 
 ``` {.aut}
-aut protocol set-operator-account 0xd4eddde5d1d0d7129a7f9c35ec55254f43b8e6d4 | aut tx sign - | aut tx send -
+aut governance set-operator-account 0xd4eddde5d1d0d7129a7f9c35ec55254f43b8e6d4 | aut tx sign - | aut tx send -
 (consider using 'KEYFILEPWD' env var).
 Enter passphrase (or CTRL-d to exit): 
 0xee513f48b4ad4cd24cfc5bb0fe0c1402a5e03ae030b6c73824bae253f56efd51
@@ -526,7 +526,7 @@ None.
 ## aut
 
 ``` {.aut}
-aut protocol set-oracle-contract [OPTIONS] CONTRACT-ADDRESS
+aut governance set-oracle-contract [OPTIONS] CONTRACT-ADDRESS
 ```
 :::
 
@@ -555,7 +555,7 @@ None.
 ## aut
 
 ``` {.aut}
-aut protocol set-stabilization-contract [OPTIONS] CONTRACT-ADDRESS
+aut governance set-stabilization-contract [OPTIONS] CONTRACT-ADDRESS
 ```
 :::
 
@@ -584,7 +584,7 @@ None.
 ## aut
 
 ``` {.aut}
-aut protocol set-supply-control-contract [OPTIONS] CONTRACT-ADDRESS
+aut governance set-supply-control-contract [OPTIONS] CONTRACT-ADDRESS
 ```
 :::
 
@@ -659,7 +659,7 @@ The updated parameter can be retrieved from state by a call to [`config()`](/ref
 ## aut
 
 ``` {.aut}
-aut protocol set-treasury-account [OPTIONS] treasury-address
+aut governance set-treasury-account [OPTIONS] treasury-address
 ```
 :::
 
@@ -669,7 +669,7 @@ aut protocol set-treasury-account [OPTIONS] treasury-address
 ## aut
 
 ``` {.aut}
-aut protocol set-treasury-account 0xd4eddde5d1d0d7129a7f9c35ec55254f43b8e6d4 | aut tx sign - | aut tx send -
+aut governance set-treasury-account 0xd4eddde5d1d0d7129a7f9c35ec55254f43b8e6d4 | aut tx sign - | aut tx send -
 (consider using 'KEYFILEPWD' env var).
 Enter passphrase (or CTRL-d to exit): 
 0xffe8725f6988668700896f335ecb5db75bb48c9dfb7caef90acecef85d0a2520
@@ -699,7 +699,7 @@ The updated parameter can be retrieved from state by a call to [`config()`](/ref
 ## aut
 
 ``` {.aut}
-aut protocol set-treasury-fee [OPTIONS] TREASURY-FEE
+aut governance set-treasury-fee [OPTIONS] TREASURY-FEE
 ```
 :::
 
@@ -709,7 +709,7 @@ aut protocol set-treasury-fee [OPTIONS] TREASURY-FEE
 ## aut
 
 ``` {.aut}
-aut protocol set-treasury-fee 100000000 | aut tx sign - | aut tx send -
+aut governance set-treasury-fee 100000000 | aut tx sign - | aut tx send -
 (consider using 'KEYFILEPWD' env var).
 Enter passphrase (or CTRL-d to exit): 
 0x513f36338720545a8f2c1111e0c2f4b5eebe9582e39493c6cd587ababe1e2e08
@@ -741,7 +741,7 @@ The updated parameter can be retrieved from state by a call to [`config()`](/ref
 ## aut
 
 ``` {.aut}
-aut protocol set-unbonding-period [OPTIONS] UNBONDING_PERIOD
+aut governance set-unbonding-period [OPTIONS] UNBONDING_PERIOD
 ```
 :::
 
@@ -751,7 +751,7 @@ aut protocol set-unbonding-period [OPTIONS] UNBONDING_PERIOD
 ## aut
 
 ``` {.aut}
-aut protocol set-unbonding-period 1000 | aut tx sign - | aut tx send -
+aut governance set-unbonding-period 1000 | aut tx sign - | aut tx send -
 (consider using 'KEYFILEPWD' env var).
 Enter passphrase (or CTRL-d to exit): 
 0x1057bf2525ee910b393ea8d54d0ec9b362355e5dbeb14235ed5eba92750a4bdd


### PR DESCRIPTION
**Description**

This PR makes edits to API Reference `aut` command groups to sync up with the aut v0.5.0 Release - https://github.com/autonity/aut/releases/tag/v0.5.0 which supports the Autonity Yamuna protocol (https://github.com/autonity/aut/pull/158)

**Tasks**

- [x] Autonity Contract Interface : drop `get-` prefix from protocol commands
- [x] Autonity Contract Interface, Governance and  Protocol only Reference: edit governance commands from `aut protocol` to `aut governance`

Note: the PR does not add additonal Governance group functions added in aut v0.5.0.  This is because the `Governance and  Protocol only Reference` page may be removed per https://github.com/autonity/docs.autonity.org/issues/177.  The goal of this PR is an iteration to keep the docs in sync with the new `aut` release.