### PR TITLE
fix total redistributed docs

### DIFF
--- a/reference/api/aut/index.md
+++ b/reference/api/aut/index.md
@@ -2004,9 +2004,9 @@ LNTN-0
 :::
 
 
-## totalRedistributed
+## atnTotalRedistributed
 
-Returns the total amount of staking rewards distributed since genesis minus treasury fee.
+Returns the total amount of Auton staking rewards distributed since genesis minus treasury fee.
 
 ### Parameters
 
@@ -2029,7 +2029,7 @@ aut protocol total-redistributed [OPTIONS]
 ## RPC
 
 ``` {.rpc}
-{"method":"aut_totalRedistributed", "params":[]}
+{"method":"aut_atnTotalRedistributed", "params":[]}
 ```
 :::
 
@@ -2045,7 +2045,7 @@ aut protocol total-redistributed -r https://rpc1.piccadilly.autonity.org
 ## RPC
 
 ``` {.rpc}
-curl -X GET 'https://rpc1.piccadilly.autonity.org/'  --header 'Content-Type: application/json' --data '{"jsonrpc":"2.0", "method":"aut_totalRedistributed", "params":[], "id":1}'
+curl -X GET 'https://rpc1.piccadilly.autonity.org/'  --header 'Content-Type: application/json' --data '{"jsonrpc":"2.0", "method":"aut_atnTotalRedistributed", "params":[], "id":1}'
 {"jsonrpc":"2.0","id":1,"result":47981813599875371606}
 ```
 :::

--- a/reference/api/aut/index.md
+++ b/reference/api/aut/index.md
@@ -2024,7 +2024,7 @@ None.
 ## aut
 
 ``` {.aut}
-aut protocol total-redistributed [OPTIONS]
+aut protocol atn-total-redistributed [OPTIONS]
 ```
 ## RPC
 
@@ -2039,7 +2039,7 @@ aut protocol total-redistributed [OPTIONS]
 ## aut
 
 ``` {.aut}
-aut protocol total-redistributed -r https://rpc1.piccadilly.autonity.org
+aut protocol atn-total-redistributed -r https://rpc1.piccadilly.autonity.org
 47981813599875371606
 ```
 ## RPC


### PR DESCRIPTION
In the last release the autonity contract variable `totalRedistributed` was renamed to `atnTotalRedistributed` (since now we have also NTN rewards). I updated the docs to reflect the change.

Not sure if also https://github.com/autonity/aut needs some changes related to this FYI @aiman @szemate 