### PR TITLE
Edits to AGC installation and networks pages for AGC v0.14.1 patch

### DIFF
--- a/networks/testnet-piccadilly/index.md
+++ b/networks/testnet-piccadilly/index.md
@@ -42,7 +42,7 @@ Piccadilly is for participants interested in:
 | `config.autonity.minBaseFee`       | `500000000` (0.5 GWei)        |
 | `config.autonity.operator`         | `0xd32C0812Fa1296F082671D5Be4CbB6bEeedC2397` |
 | `config.autonity.treasury`         | `0xF74c34Fed10cD9518293634C6f7C12638a808Ad5` |
-| `config.autonity.validators`       |  See [`Validators`](https://github.com/autonity/autonity/blob/release/v0.14.0/params/config.go#L100) object in the AGC `PiccadillyChainConfig` for details.  |
+| `config.autonity.validators`       |  See [`Validators`](https://github.com/autonity/autonity/blob/release/v0.14.1/params/config.go#L100) object in the AGC `PiccadillyChainConfig` for details.  |
 | `config.oracle.symbols`       | `["AUD-USD", "CAD-USD", "EUR-USD", "GBP-USD", "JPY-USD", "SEK-USD", "ATN-USD", "NTN-USD", "ATN-NTN"]`        |
 | `config.oracle.votePeriod`       | `30` (30 blocks)       |
 
@@ -61,7 +61,7 @@ The network bootnode addresses are:
 
 The current iteration of the Piccadilly network is built using:
 
-- Autonity Go Client (AGC) Release: [v0.14.0](https://github.com/autonity/autonity/releases/tag/v0.14.0). The docker image release is: `ghcr.io/autonity/autonity:latest`
+- Autonity Go Client (AGC) Release: [v0.14.1](https://github.com/autonity/autonity/releases/tag/v0.14.1). The docker image release is: `ghcr.io/autonity/autonity:v0.14.1`
 
 - Autonity Oracle Server (AOS) Release: [v0.1.9](https://github.com/autonity/autonity-oracle/releases/tag/v0.1.9). The docker image release is: `ghcr.io/autonity/autonity-oracle-piccadilly:latest`
 

--- a/node-operators/install-aut/index.md
+++ b/node-operators/install-aut/index.md
@@ -18,6 +18,8 @@ It is recommended not run Autonity using Docker containers outside of a test env
 
 ::: {.callout-note title="Note" collapse="false"}
 Client source code is versioned on a 3-digit `major.minor.patch` versioning scheme, and hosted and maintained in the public GitHub repo [autonity](https://github.com/autonity/autonity/).
+
+Before installing verify the correct Autonity Go Client release version to install for the network you are connecting to. See the [Networks](/networks/) pages [Bakerloo Testnet, Release](/networks/testnet-bakerloo/#release) and [Piccadilly Testnet, Release](/networks/testnet-piccadilly/#release) for the versions deployed.
 :::
 
 ## Requirements
@@ -125,7 +127,7 @@ The following should be installed in order to build the Autonity Go Client:
 2. Enter the `autonity` directory and ensure you are building from the correct release. This can be done by checking out the Release Tag in a branch:
 
     ```bash
-    git checkout tags/v0.14.0 -b v0.14.0
+    git checkout tags/v0.14.1 -b v0.14.1
     ```
 
 3. Build autonity:
@@ -206,7 +208,7 @@ sudo systemctl restart docker
    If you are deploying to the Piccadilly Testnet:
    
     ```bash
-    docker pull ghcr.io/autonity/autonity:latest
+    docker pull ghcr.io/autonity/autonity:v0.14.1
     ```
 
    (where `latest` can be replaced with another version)
@@ -230,7 +232,7 @@ sudo systemctl restart docker
     ```bash
     docker images --digests ghcr.io/autonity/autonity
     REPOSITORY                  TAG       DIGEST                                                                    IMAGE ID       CREATED         SIZE
-    ghcr.io/autonity/autonity   latest    sha256:25ee8fcfc158c2396f43c8dfb02dff268e0089c846fedd7cb6934e28f6a8b7d1   487ecdf178f8   4 months ago    56MB
+    ghcr.io/autonity/autonity   v0.14.1   sha256:0c2716615e47f22a5fb8b28f29f5b796ed45aaf75aa592ebed07f98de0a43374   c3e1d60a1853   22 hours ago    57.8MB
     ```
 
 ::: {.callout-note title="Info" collapse="false"}
@@ -247,12 +249,12 @@ $ ./autonity version
 ```
 ```
 Autonity
-Version: 0.14.0
-Git Commit: 15cd01644a4b19d70c654bc334f04fab851f2466
-Git Commit Date: 20240619
+Version: 0.14.1
+Git Commit: a5d0ecda73fab7ea81c5eaf648f83f393f1728ec
+Git Commit Date: 20240911
 Architecture: amd64
 Protocol Versions: [66]
-Go Version: go1.22.4
+Go Version: go1.22.0
 Operating System: linux
 GOPATH=
 GOROOT=
@@ -261,15 +263,15 @@ GOROOT=
 If using Docker, the setup of the image can be verified with:
 
 ```bash
-$ docker run --rm ghcr.io/autonity/autonity:latest version
+$ docker run --rm ghcr.io/autonity/autonity:v0.14.1 version
 ```
 
 ```
 Autonity
-Version: 0.14.0
+Version: 0.14.1
 Architecture: amd64
 Protocol Versions: [66]
-Go Version: go1.21.7
+Go Version: go1.22.0
 Operating System: linux
 GOPATH=
 GOROOT=/usr/local/go

--- a/oracle/install-oracle/index.md
+++ b/oracle/install-oracle/index.md
@@ -16,6 +16,8 @@ We assume that the Autonity Oracle Server will run on a _host_ machine (a VPS or
 
 ::: {.callout-note title="Note" collapse="false"}
 Autonity Oracle Server source code is versioned on a 3-digit `major.minor.patch` versioning scheme, and hosted and maintained in the public GitHub repo [autonity-oracle](https://github.com/autonity/autonity-oracle).
+
+Before installing verify the correct Autonity Oracle Server release version to use for the network you are connecting to. See the [Networks](/networks/) pages [Bakerloo Testnet, Release](/networks/testnet-bakerloo/#release) and [Piccadilly Testnet, Release](/networks/testnet-piccadilly/#release) for the versions deployed.
 :::
 
 ## Requirements


### PR DESCRIPTION
This PR makes minor edits to the docs for the v0.14.1 AGC patch release - https://github.com/autonity/autonity/releases/tag/v0.14.1 

The patch is backward compatible with v0.14.0 and is being applied to Piccadilly validators per reasons stated in the Release notes.

This PR edits the docs to:

- Update to v0.14.1 section https://docs.autonity.org/networks/testnet-piccadilly/#release
- Update to v0.4.1 the AGC installation page https://docs.autonity.org/node-operators/install-aut/
- Update the install page heading section note box to add checking the network page Release sections to verify which version to install for the network being connected to: https://docs.autonity.org/node-operators/install-aut/#overview, https://docs.autonity.org/oracle/install-oracle/#overview