### PR TITLE
Update deprecated github download- and upload- artifact action versions

### DIFF
--- a/.github/workflows/publish-site.yml
+++ b/.github/workflows/publish-site.yml
@@ -22,7 +22,7 @@ jobs:
         uses: quarto-dev/quarto-actions/render@v2
 
       - name: Archive site
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: site
           path: docs/
@@ -42,7 +42,7 @@ jobs:
           aws-region: eu-west-2
 
       - name: Download site archive
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v4
         with:
           name: site
           path: docs/


### PR DESCRIPTION
Update GitHub `upload-artifact@v2` and `download-artifact@v2` to `@v4` following deprecation.

Update per Github recommendation, see:

- https://github.blog/changelog/2024-02-13-deprecation-notice-v1-and-v2-of-the-artifact-actions/
- https://github.blog/news-insights/product-news/get-started-with-v4-of-github-actions-artifacts/