### PR TITLE
add gh pages

### DIFF
--- a/.github/workflows/publish-gh.yml
+++ b/.github/workflows/publish-gh.yml
@@ -2,7 +2,7 @@ name: Publish Site to Github pages - Staging
 on:
   workflow_dispatch:
   push:
-    branches: develop
+    branches: staging
 jobs:
   build-deploy:
     runs-on: ubuntu-latest
@@ -15,7 +15,7 @@ jobs:
       - name: Set up Quarto
         uses: quarto-dev/quarto-actions/setup@v2
         with:
-          version: 1.3.361
+          version: 1.4
 
       - name: Render and Publish
         uses: quarto-dev/quarto-actions/publish@v2

--- a/.github/workflows/publish-gh.yml
+++ b/.github/workflows/publish-gh.yml
@@ -23,3 +23,4 @@ jobs:
           target: gh-pages
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        working-directory: docs

--- a/.github/workflows/publish-gh.yml
+++ b/.github/workflows/publish-gh.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Set up Quarto
         uses: quarto-dev/quarto-actions/setup@v2
         with:
-          version: 1.4
+          version: 1.4.551
 
       - name: Render and Publish
         uses: quarto-dev/quarto-actions/publish@v2
@@ -23,4 +23,3 @@ jobs:
           target: gh-pages
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        working-directory: docs

--- a/README.md
+++ b/README.md
@@ -52,8 +52,6 @@ The repo is configured to publish:
 
 The staging site is available [here](https://autonity.github.io/docs.autonity.org/). The staging site is updated automatically on every push to the `staging` branch.
   
-For further details on merging or rebasing branches, see the [Git Workflow Wiki Page](https://example.com/wiki).
-
 See the repo Wiki Page [Git Workflow](https://github.com/autonity/game.autonity.org/wiki/Git-Workflow) for [when to `merge` or `rebase` branches when working on `game.autonity.org`](https://github.com/autonity/game.autonity.org/wiki/Git-Workflow#when-to-merge-and-rebase-when-working-on-gameautonityorg) repo.
 
 ## Other Piccadilly site resources

--- a/README.md
+++ b/README.md
@@ -45,10 +45,14 @@ The repo is configured to publish:
 
 ## Development workflow
 
-- The `master` branch will always have the live production version of the website.
-- A hot-fix to the production site is published by creating a branch from `master` with the hot-fix, and creating a PR.  (Once the hot-fix has been merged, `master` should be merged to `develop` to ensure that the fix is propagated, and that conflicts are resolved in `develop`.)
-- The `develop` branch will always have the WIP next version of the website being prepared.
-- A new version of the production website is published by merging `develop` into `master`.
+- The `master` branch will always contain the live production version of the website.
+- The `develop` branch will be used for ongoing development and feature testing. All changes should be pushed to `develop` first, where they can be tested on a staging server before being merged into `master`.
+- Hot-fixes to the production site should be handled by creating a branch from `master`, implementing the fix, and creating a PR. Once the hot-fix is merged, `master` should be merged into `develop` to ensure the fix is propagated and conflicts are resolved.
+- A new version of the production website is published by merging `develop` into `master` after thorough testing.
+
+The staging site is available [here](https://autonity.github.io/docs.autonity.org/). The staging site is updated automatically on every push to the `staging` branch.
+  
+For further details on merging or rebasing branches, see the [Git Workflow Wiki Page](https://example.com/wiki).
 
 See the repo Wiki Page [Git Workflow](https://github.com/autonity/game.autonity.org/wiki/Git-Workflow) for [when to `merge` or `rebase` branches when working on `game.autonity.org`](https://github.com/autonity/game.autonity.org/wiki/Git-Workflow#when-to-merge-and-rebase-when-working-on-gameautonityorg) repo.
 


### PR DESCRIPTION
This PR is part of <https://github.com/autonity/docs.autonity.org/issues/227>. It updates the gh_pages workflow so that any merges to the staging server will be published to gh_pages for testing and review.

- **update the gh_pages workflow**
- **update readme** (also includes link to ghpage)
