### PR TITLE
Update the ui for the auto generated solidity contract documentation

### DIFF
--- a/_filters/footer-navigation.lua
+++ b/_filters/footer-navigation.lua
@@ -1,0 +1,73 @@
+--[[
+  This script adds footer navigation buttons to the bottom of the page.
+  it is called with:
+  ::: {.footer-navigation ....} 
+  :::
+
+  and takes the following attributes:
+    - prev-url: the url of the previous page
+    - prev-contract: the name of the previous contract
+    - next-url: the url of the next page
+    - next-contract: the name of the next contract
+  if no prev-url or next-url is provided, the corresponding button will not be displayed.
+
+  complete example
+  ::: {.footer-navigation prev-url="previous-page.qmd" prev-contract="Previous Contract Name" next-url="next-page.qmd" next-contract="Next Contract Name"}
+  :::
+]]--
+
+function Div(el)
+    if el.classes:includes("footer-navigation") then
+      
+      local prev_url = el.attributes["prev-url"]
+      local prev_contract = el.attributes["prev-contract"] or "Previous contract"
+      local prev_text = "Previous"
+      
+      local next_url = el.attributes["next-url"]
+      local next_contract = el.attributes["next-contract"] or "Next contract"
+      local next_text = "Next"
+      
+      local wrapper_html = [[
+        <div class="footer-navigation">
+          %s
+        </div>
+      ]]
+      
+      local prev_html = ""
+      if prev_url then
+        prev_html = string.format([[
+          <div class="footer-link prev-link">
+            <a href="%s">
+             <img class="footer-link-image" src="/_assets/images/chevron-left.svg" class="img-fluid">
+            <div class="footer-link-text">
+              <span>%s</span>
+              <span class="contract-name">%s</span>
+            </div>             
+            </a>
+          </div>
+        ]], prev_url, prev_text, prev_contract)
+      end
+
+      local next_html = ""
+      if next_url then
+        next_html = string.format([[
+          <div class="footer-link next-link">
+            <a href="%s">
+              <div class="footer-link-text">
+                <span>%s</span>
+                <span class="contract-name">%s</span>
+              </div>
+              <img class="footer-link-image" src="/_assets/images/chevron-right.svg" class="img-fluid">
+            </a>
+          </div>
+        ]], next_url, next_text, next_contract)
+      end
+
+      local combined_html = string.format('%s%s', prev_html, next_html)
+
+      if combined_html ~= "" then
+        local wrapped_html = string.format(wrapper_html, combined_html)
+        return pandoc.RawBlock('html', wrapped_html)
+      end
+    end
+end

--- a/_filters/mutability.lua
+++ b/_filters/mutability.lua
@@ -1,0 +1,25 @@
+function Div(el)
+    if el.classes:includes("mutability") then
+        local mutability_type = el.attributes["mutability-type"]
+
+        local color_class = ""
+        if mutability_type == "payable" then
+            color_class = "payable-tag"
+        elseif mutability_type == "view" then
+            color_class = "view-tag"
+        elseif mutability_type == "pure" then
+            color_class = "pure-tag"
+        end
+
+        local tag_html = ""
+        if color_class ~= "" then
+            tag_html = string.format([[
+                <div class="mutability-wrapper"><span class="mutability-tag %s">%s</span></div>
+            ]], color_class, mutability_type)
+        end
+
+        if tag_html ~= "" then
+            return pandoc.RawBlock('html', tag_html)
+        end
+    end
+end

--- a/_quarto.yml
+++ b/_quarto.yml
@@ -98,6 +98,8 @@ website:
       - icon: youtube
         href: https://www.youtube.com/channel/UCBMTGESIYJzXy-MfojATRqQ
 filters:
+  - _filters/footer-navigation.lua
+  - _filters/mutability.lua
   - _filters/macro-substitution.lua
   - _filters/page-info.lua
   - _filters/card-substitution.lua

--- a/_quarto.yml
+++ b/_quarto.yml
@@ -74,6 +74,7 @@ website:
       - "developer/custom-networks/index.md"
     - section: "Reference"
       contents:
+      - auto: reference/contracts
       - auto: reference/cli
       - auto: reference/api  
       - "reference/codebase/index.md"

--- a/_theme/theme.scss
+++ b/_theme/theme.scss
@@ -58,7 +58,11 @@ $text-muted: #6a737b;
 $font-family-monospace: 'Berkeley Mono', monospace;
 $font-size-root: 0.95rem;
 
-
+:root {
+    --secondary-border: var(--border-thickness) solid var(--bs-body-color);
+    --primary-border: var(--border-thickness) solid var(--bs-body-color);
+    --border-thickness: 1.53px;
+}
 /*-- scss:rules --*/
 body {
     font-family: proxima nova,sans-serif;
@@ -129,4 +133,52 @@ h5 {
 */
 .footer-list {
     white-space: nowrap;
+}
+
+
+.footer-link {
+    border: var(--primary-border);
+    font-family: var(--header-font);
+    padding: 30px;
+    width: 50%;
+}
+
+.footer-link:hover {
+    border-color: var(--highlight-color);
+}
+
+.footer-link > a {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    text-decoration: none;
+    color: var(--foreground-color);
+}
+
+.footer-navigation {
+    display: flex;
+    gap: 15px;
+}
+img.footer-link-image {
+    width: 15px;
+}
+.footer-link-text {
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+}
+
+.prev-link>a>.footer-link-text {    
+    align-items: end;
+}
+
+.footer-link:hover .contract-name {
+    color: var(--highlight-color);
+}
+
+
+@media (min-width: 1200px) {
+    h3, .h3 {
+        font-size: 1.25rem;
+    }
 }

--- a/_theme/theme.scss
+++ b/_theme/theme.scss
@@ -62,6 +62,9 @@ $font-size-root: 0.95rem;
     --secondary-border: var(--border-thickness) solid var(--bs-body-color);
     --primary-border: var(--border-thickness) solid var(--bs-body-color);
     --border-thickness: 1.53px;
+    --green: #528f18;
+    --blue: #5656e9;
+    --purple: #906ce3;
 }
 /*-- scss:rules --*/
 body {
@@ -176,9 +179,69 @@ img.footer-link-image {
     color: var(--highlight-color);
 }
 
-
 @media (min-width: 1200px) {
     h3, .h3 {
         font-size: 1.25rem;
     }
+}
+
+table.table {
+    border: var(--primary-border);
+}
+
+.table>thead {
+    border-top-width: 0;
+    border: var(--primary-border);
+}
+
+.table>:not(caption)>*>* {
+    border: var(--primary-border);
+}
+td {
+    width: 33%;
+}
+
+
+.payable-tag {
+    color: var(--green);
+}
+
+.view-tag { 
+    color: var(--blue);
+}
+
+.pure-tag {
+    color: var(--purple);
+}
+
+.mutability-wrapper {
+    position: relative;
+    width: 100%;
+}
+
+.mutability-tag {
+    border: var(--primary-border);
+    padding: 2px 12px;
+    font-size: 12px;
+    font-weight: bold;
+    position: absolute;
+    right: 0px;
+    width: 74px;
+    text-align: center;
+    top: -30px;
+}
+
+TOC .nav-link {
+    width: 100%;
+    max-width: 250px;
+}
+#TOC ul li a {
+    display: block;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    max-width: 100%;
+}
+.sidebar nav[role=doc-toc] ul>li>ul>li>a {
+    padding-left: 1.2em;
 }

--- a/reference/contracts/autonity/test.md
+++ b/reference/contracts/autonity/test.md
@@ -1,0 +1,235 @@
+---
+title: "Oracle"
+---
+
+## Events
+
+### [InnocenceProven(address,uint256)](https://github.com/autonity/autonity/tree/v0.14.1/autonity/solidity/contracts/interfaces/IAccountability.sol#L39)
+
+Event emitted after receiving a proof-of-innocence cancelling an accusation.
+
+#### Parameters
+
+| Name | Type |
+| --- | --- |
+| _offender | address |
+| _id | uint256 |
+
+### [NewAccusation(address,uint256,uint256)](https://github.com/autonity/autonity/tree/v0.14.1/autonity/solidity/contracts/interfaces/IAccountability.sol#L34)
+
+Event emitted after receiving an accusation, the reported validator has a certain amount of time to submit a proof-of-innocence, otherwise, he gets slashed.
+
+#### Parameters
+
+| Name | Type |
+| --- | --- |
+| _offender | address |
+| _severity | uint256 |
+| _id | uint256 |
+
+### [NewFaultProof(address,uint256,uint256)](https://github.com/autonity/autonity/tree/v0.14.1/autonity/solidity/contracts/interfaces/IAccountability.sol#L28)
+
+Event emitted when a fault proof has been submitted. The reported validator will be silencied and slashed at the end of the current epoch.
+
+#### Parameters
+
+| Name | Type |
+| --- | --- |
+| _offender | address |
+| _severity | uint256 |
+| _id | uint256 |
+
+### [SlashingEvent(address,uint256,uint256,bool,uint256)](https://github.com/autonity/autonity/tree/v0.14.1/autonity/solidity/contracts/interfaces/IAccountability.sol#L44)
+
+Event emitted after a successful slashing.
+
+#### Parameters
+
+| Name | Type |
+| --- | --- |
+| validator | address |
+| amount | uint256 |
+| releaseBlock | uint256 |
+| isJailbound | bool |
+| eventId | uint256 |
+
+## Functions
+
+### [beneficiaries(address)](https://github.com/autonity/autonity/tree/v0.14.1/autonity/solidity/contracts/Accountability.sol#L75)
+
+#### Parameters
+
+| Type |
+| --- |
+| address |
+
+#### Returns
+
+| Type |
+| --- |
+| address |
+
+### [canAccuse(address,uint8,uint256)](https://github.com/autonity/autonity/tree/v0.14.1/autonity/solidity/contracts/Accountability.sol#L180)
+
+#### Parameters
+
+| Name | Type |
+| --- | --- |
+| _offender | address |
+| _rule | uint8 |
+| _block | uint256 |
+
+#### Returns
+
+| Name | Type |
+| --- | --- |
+| _result | bool |
+| _deadline | uint256 |
+
+### [canSlash(address,uint8,uint256)](https://github.com/autonity/autonity/tree/v0.14.1/autonity/solidity/contracts/Accountability.sol#L172)
+
+#### Parameters
+
+| Name | Type |
+| --- | --- |
+| _offender | address |
+| _rule | uint8 |
+| _block | uint256 |
+
+#### Returns
+
+| Type |
+| --- |
+| bool |
+
+### [config()](https://github.com/autonity/autonity/tree/v0.14.1/autonity/solidity/contracts/Accountability.sol#L72)
+
+#### Returns
+
+| Name | Type |
+| --- | --- |
+| innocenceProofSubmissionWindow | uint256 |
+| baseSlashingRateLow | uint256 |
+| baseSlashingRateMid | uint256 |
+| collusionFactor | uint256 |
+| historyFactor | uint256 |
+| jailFactor | uint256 |
+| slashingRatePrecision | uint256 |
+
+### [distributeRewards(address,uint256)](https://github.com/autonity/autonity/tree/v0.14.1/autonity/solidity/contracts/Accountability.sol#L120)
+
+called by the Autonity Contract at block finalization, to reward the reporter of a valid proof.
+
+#### Parameters
+
+| Name | Type | Description |
+| --- | --- | --- |
+| _validator | address | validator account which got slashed. |
+| _ntnReward | uint256 | total amount of ntn to be transferred to the repoter. MUST BE AVAILABLE in the accountability contract balance. |
+
+### [epochPeriod()](https://github.com/autonity/autonity/tree/v0.14.1/autonity/solidity/contracts/Accountability.sol#L21)
+
+#### Returns
+
+| Type |
+| --- |
+| uint256 |
+
+### [events(uint256)](https://github.com/autonity/autonity/tree/v0.14.1/autonity/solidity/contracts/Accountability.sol#L71)
+
+#### Parameters
+
+| Type |
+| --- |
+| uint256 |
+
+#### Returns
+
+| Name | Type |
+| --- | --- |
+| chunks | uint8 |
+| chunkId | uint8 |
+| eventType | uint8 |
+| rule | uint8 |
+| reporter | address |
+| offender | address |
+| rawProof | bytes |
+| id | uint256 |
+| block | uint256 |
+| epoch | uint256 |
+| reportingBlock | uint256 |
+| messageHash | uint256 |
+
+### [finalize(bool)](https://github.com/autonity/autonity/tree/v0.14.1/autonity/solidity/contracts/Accountability.sol#L105)
+
+called by the Autonity Contract at block finalization, before processing reward redistribution.
+
+#### Parameters
+
+| Name | Type | Description |
+| --- | --- | --- |
+| _epochEnd | bool | whether or not the current block is the last one from the epoch. |
+
+### [getValidatorAccusation(address)](https://github.com/autonity/autonity/tree/v0.14.1/autonity/solidity/contracts/Accountability.sol#L197)
+
+#### Parameters
+
+| Name | Type |
+| --- | --- |
+| _val | address |
+
+#### Returns
+
+| Type |
+| --- |
+| tuple |
+
+### [getValidatorFaults(address)](https://github.com/autonity/autonity/tree/v0.14.1/autonity/solidity/contracts/Accountability.sol#L202)
+
+#### Parameters
+
+| Name | Type |
+| --- | --- |
+| _val | address |
+
+#### Returns
+
+| Type |
+| --- |
+| tuple[] |
+
+### [handleEvent(tuple)](https://github.com/autonity/autonity/tree/v0.14.1/autonity/solidity/contracts/Accountability.sol#L143)
+
+#### Parameters
+
+| Name | Type |
+| --- | --- |
+| _event | tuple |
+
+### [setEpochPeriod(uint256)](https://github.com/autonity/autonity/tree/v0.14.1/autonity/solidity/contracts/Accountability.sol#L523)
+
+called by the Autonity Contract when the epoch period is updated.
+
+#### Parameters
+
+| Name | Type | Description |
+| --- | --- | --- |
+| _newPeriod | uint256 | the new epoch period. |
+
+### [slashingHistory(address,uint256)](https://github.com/autonity/autonity/tree/v0.14.1/autonity/solidity/contracts/Accountability.sol#L86)
+
+#### Parameters
+
+| Type |
+| --- |
+| address |
+| uint256 |
+
+#### Returns
+
+| Type |
+| --- |
+| uint256 |
+
+::: {.footer-navigation prev-url="previous-page.qmd" prev-contract="Previous Contract Name" next-url="next-page.qmd" next-contract="Next Contract Name"}
+:::

--- a/reference/contracts/test.md
+++ b/reference/contracts/test.md
@@ -1,0 +1,242 @@
+---
+title: "Accountability"
+---
+
+## Events
+
+### [InnocenceProven(address,uint256)](https://github.com/autonity/autonity/tree/v0.14.1/autonity/solidity/contracts/interfaces/IAccountability.sol#L39)
+
+Event emitted after receiving a proof-of-innocence cancelling an accusation.
+
+#### Parameters
+
+| Name | Type |
+| --- | --- |
+| _offender | address |
+| _id | uint256 |
+
+### [NewAccusation(address,uint256,uint256)](https://github.com/autonity/autonity/tree/v0.14.1/autonity/solidity/contracts/interfaces/IAccountability.sol#L34)
+
+Event emitted after receiving an accusation, the reported validator has a certain amount of time to submit a proof-of-innocence, otherwise, he gets slashed.
+
+#### Parameters
+
+| Name | Type |
+| --- | --- |
+| _offender | address |
+| _severity | uint256 |
+| _id | uint256 |
+
+### [NewFaultProof(address,uint256,uint256)](https://github.com/autonity/autonity/tree/v0.14.1/autonity/solidity/contracts/interfaces/IAccountability.sol#L28)
+
+Event emitted when a fault proof has been submitted. The reported validator will be silencied and slashed at the end of the current epoch.
+
+#### Parameters
+
+| Name | Type |
+| --- | --- |
+| _offender | address |
+| _severity | uint256 |
+| _id | uint256 |
+
+### [SlashingEvent(address,uint256,uint256,bool,uint256)](https://github.com/autonity/autonity/tree/v0.14.1/autonity/solidity/contracts/interfaces/IAccountability.sol#L44)
+
+Event emitted after a successful slashing.
+
+#### Parameters
+
+| Name | Type |
+| --- | --- |
+| validator | address |
+| amount | uint256 |
+| releaseBlock | uint256 |
+| isJailbound | bool |
+| eventId | uint256 |
+
+## Functions
+
+### [beneficiaries(address)](https://github.com/autonity/autonity/tree/v0.14.1/autonity/solidity/contracts/Accountability.sol#L75)
+
+#### Parameters
+
+| Type |
+| --- |
+| address |
+
+#### Returns
+
+| Type |
+| --- |
+| address |
+
+### [canAccuse(address,uint8,uint256)](https://github.com/autonity/autonity/tree/v0.14.1/autonity/solidity/contracts/Accountability.sol#L180)
+
+#### Parameters
+
+| Name | Type |
+| --- | --- |
+| _offender | address |
+| _rule | uint8 |
+| _block | uint256 |
+
+#### Returns
+
+| Name | Type |
+| --- | --- |
+| _result | bool |
+| _deadline | uint256 |
+
+### [canSlash(address,uint8,uint256)](https://github.com/autonity/autonity/tree/v0.14.1/autonity/solidity/contracts/Accountability.sol#L172)
+
+#### Parameters
+
+| Name | Type |
+| --- | --- |
+| _offender | address |
+| _rule | uint8 |
+| _block | uint256 |
+
+#### Returns
+
+| Type |
+| --- |
+| bool |
+
+### [config()](https://github.com/autonity/autonity/tree/v0.14.1/autonity/solidity/contracts/Accountability.sol#L72)
+
+#### Returns
+
+| Name | Type |
+| --- | --- |
+| innocenceProofSubmissionWindow | uint256 |
+| baseSlashingRateLow | uint256 |
+| baseSlashingRateMid | uint256 |
+| collusionFactor | uint256 |
+| historyFactor | uint256 |
+| jailFactor | uint256 |
+| slashingRatePrecision | uint256 |
+
+### [distributeRewards(address,uint256)](https://github.com/autonity/autonity/tree/v0.14.1/autonity/solidity/contracts/Accountability.sol#L120)
+
+called by the Autonity Contract at block finalization, to reward the reporter of a valid proof.
+
+#### Parameters
+
+| Name | Type | Description |
+| --- | --- | --- |
+| _validator | address | validator account which got slashed. |
+| _ntnReward | uint256 | total amount of ntn to be transferred to the repoter. MUST BE AVAILABLE in the accountability contract balance. |
+
+### [epochPeriod()](https://github.com/autonity/autonity/tree/v0.14.1/autonity/solidity/contracts/Accountability.sol#L21)
+
+#### Returns
+
+| Type |
+| --- |
+| uint256 |
+
+### [events(uint256)](https://github.com/autonity/autonity/tree/v0.14.1/autonity/solidity/contracts/Accountability.sol#L71)
+
+#### Parameters
+
+| Type |
+| --- |
+| uint256 |
+
+#### Returns
+
+| Name | Type |
+| --- | --- |
+| chunks | uint8 |
+| chunkId | uint8 |
+| eventType | uint8 |
+| rule | uint8 |
+| reporter | address |
+| offender | address |
+| rawProof | bytes |
+| id | uint256 |
+| block | uint256 |
+| epoch | uint256 |
+| reportingBlock | uint256 |
+| messageHash | uint256 |
+
+### [finalize(bool)](https://github.com/autonity/autonity/tree/v0.14.1/autonity/solidity/contracts/Accountability.sol#L105)
+
+called by the Autonity Contract at block finalization, before processing reward redistribution.
+
+#### Parameters
+
+| Name | Type | Description |
+| --- | --- | --- |
+| _epochEnd | bool | whether or not the current block is the last one from the epoch. |
+
+### [getValidatorAccusation(address)](https://github.com/autonity/autonity/tree/v0.14.1/autonity/solidity/contracts/Accountability.sol#L197)
+
+#### Parameters
+
+| Name | Type |
+| --- | --- |
+| _val | address |
+
+#### Returns
+
+| Type |
+| --- |
+| tuple |
+
+### [getValidatorFaults(address)](https://github.com/autonity/autonity/tree/v0.14.1/autonity/solidity/contracts/Accountability.sol#L202)
+
+#### Parameters
+
+| Name | Type |
+| --- | --- |
+| _val | address |
+
+#### Returns
+
+| Type |
+| --- |
+| tuple[] |
+
+### [handleEvent(tuple)](https://github.com/autonity/autonity/tree/v0.14.1/autonity/solidity/contracts/Accountability.sol#L143)
+::: {.mutability mutability-type="payable"}
+:::
+
+#### Parameters
+
+| Name | Type |
+| --- | --- |
+| _event | tuple |
+::: {.method-title}
+### [setEpochPeriod(uint256)](https://github.com/autonity/autonity/tree/v0.14.1/autonity/solidity/contracts/Accountability.sol#L523)
+::: {.mutability mutability-type="view"}
+:::
+:::
+
+called by the Autonity Contract when the epoch period is updated.
+
+#### Parameters
+
+| Name | Type | Description |
+| --- | --- | --- |
+| _newPeriod | uint256 | the new epoch period. |
+
+### [slashingHistory(address,uint256)](https://github.com/autonity/autonity/tree/v0.14.1/autonity/solidity/contracts/Accountability.sol#L86)
+::: {.mutability mutability-type="pure"}
+:::
+
+#### Parameters
+
+| Type |
+| --- |
+| address |
+| uint256 |
+
+#### Returns
+
+| Type |
+| --- |
+| uint256 |
+
+::: {.footer-navigation prev-url="previous-page.qmd" prev-contract="Previous Contract Name"}
+:::


### PR DESCRIPTION
This PR splits out the auto generated contract documentation updates from the other more generic styling updates: <https://github.com/autonity/docs.autonity.org/pull/223>

- Add footer navigation
- Add "pure/view/payable" tags (lets iterate on where we want this to be).
- update styling for the auto generated documentation.
