### PR TITLE
Update theme so that content margins can be adjusted

### DIFF
--- a/_quarto.yml
+++ b/_quarto.yml
@@ -74,7 +74,6 @@ website:
       - "developer/custom-networks/index.md"
     - section: "Reference"
       contents:
-      - auto: reference/contracts
       - auto: reference/cli
       - auto: reference/api  
       - "reference/codebase/index.md"

--- a/_quarto.yml
+++ b/_quarto.yml
@@ -74,6 +74,7 @@ website:
       - "developer/custom-networks/index.md"
     - section: "Reference"
       contents:
+      - auto: reference/contracts
       - auto: reference/cli
       - auto: reference/api  
       - "reference/codebase/index.md"

--- a/_theme/theme.scss
+++ b/_theme/theme.scss
@@ -259,7 +259,7 @@ section:target::before {
 .method-title {
     display: flex;
     justify-content: space-between;
-    margin-top: 1.5rem;
+    margin-top: 2rem;
     margin-bottom: 7.6px;
 }
 
@@ -283,4 +283,14 @@ section:target::before {
     font-size: .75em;
     font-weight: bold;
     text-align: center;
+}
+
+section#events h4,
+section#functions h4 {
+    margin: 0px;
+}
+
+section#events p,
+section#functions p {
+    margin-bottom: 8px;
 }

--- a/_theme/theme.scss
+++ b/_theme/theme.scss
@@ -259,7 +259,7 @@ section:target::before {
 .method-title {
     display: flex;
     justify-content: space-between;
-    margin-top: 2rem;
+    margin-top: 2.5rem;
     margin-bottom: 7.6px;
 }
 


### PR DESCRIPTION
This PR addresses an [issue](https://github.com/autonity/docs.autonity.org/issues/243) where the global styling for `h4` and `p` tags caused the content in the auto-generated documentation to appear disjointed, making it difficult to distinguish between different sections, such as where one function ends and another begins.

To resolve this, I’ve added two new CSS rules that specifically target the `h4` and `p` tags within the auto-generated content. These adjustments improve the margins, enhancing both legibility and content grouping.

![image](https://github.com/user-attachments/assets/075735d7-a456-4a89-a53a-fe952f40306f)

