### PR TITLE
Fix contract API reference index

### DIFF
--- a/_apidocgen/contract.py
+++ b/_apidocgen/contract.py
@@ -52,11 +52,15 @@ def generate_contract_doc(
     abi = sorted(abi, key=lambda element: element.get("name", ""))  # type: ignore
     doc = MarkdownDocument()
 
-    doc.add_meta({"title": config["display_name"]})
-    if "notice" in userdoc:
-        doc.add_paragraph(userdoc["notice"])
-    else:
+    if "notice" not in userdoc:
         logger.warning("contract is missing @notice")
+
+    doc.add_meta(
+        {
+            "title": config["display_name"],
+            "description": userdoc.get("notice", " "),
+        }
+    )
 
     for element_type in (ElementType.EVENT, ElementType.FUNCTION):
         if abi_elements := eth_utils.filter_abi_by_type(str(element_type), abi):  # type: ignore

--- a/_assets/css/styles.css
+++ b/_assets/css/styles.css
@@ -546,3 +546,7 @@ span.resource {
 td, td * {
     word-break: break-all;
 }
+
+.listing-description {
+    word-break: normal;
+}


### PR DESCRIPTION
- [Add contract description to metadata and not to page content in API docs](https://github.com/autonity/docs.autonity.org/commit/a554f8915e6800eb41f5f693e6a08c3fb47dff91)
- [Disable word break in listing description](https://github.com/autonity/docs.autonity.org/commit/613be41f57dd928eb39e821e9c3fddc32268ffba)

Resolves #244.