### PR TITLE
Update for Mainnet Release versions

### DIFF
--- a/networks/mainnet/index.md
+++ b/networks/mainnet/index.md
@@ -51,7 +51,7 @@ The network's genesis configuration is:
 | `config.autonity.minBaseFee`       | `10_000_000_000` (10 GWei)    |
 | `config.autonity.operator`         | `0x83e5e0eab996Bb894814fa8F0AC96a0D314f06F3` |
 | `config.autonity.treasury`         | `0xd735174cf1d0D9150cb57750C45B6e8095160f6A` |
-| `config.autonity.validators`       |  See `Validators` in the AGC [`MainnetChainConfig`](https://github.com/autonity/autonity/blob/release/v1.1.1/params/config.go)) for details.  |
+| `config.autonity.validators`       |  See `MainnetValidators` in the AGC [`Mainnet Config`](https://github.com/autonity/autonity/blob/release/v1.1.2/params/mainnet_config.go#L158)) for details.  |
 | `config.oracle.symbols`            | `['AUD-USD','CAD-USD','EUR-USD','GBP-USD','JPY-USD','SEK-USD']`        |
 | `config.oracle.votePeriod`         | `600` (600  blocks)          |
 
@@ -71,9 +71,9 @@ The network bootnode addresses are:
 
 Mainnet is built using:
 
-- Autonity Go Client (AGC) Release: [v1.1.1](https://github.com/autonity/autonity/releases/tag/v1.1.1). The docker image release is: `ghcr.io/autonity/autonity:v1.1.1`.
+- Autonity Go Client (AGC) Release: [v1.1.2](https://github.com/autonity/autonity/releases/tag/v1.1.2). The docker image release is: [`ghcr.io/autonity/autonity:v1.1.2`](https://github.com/autonity/autonity/pkgs/container/autonity/480778709?tag=v1.1.2).
 
-- Autonity Oracle Server (AOS) Release: [v0.2.4](https://github.com/autonity/autonity-oracle/releases/tag/v0.2.4). The docker image release is: `ghcr.io/autonity/autonity-oracle:v0.2.4`.
+- Autonity Oracle Server (AOS) Release: [v0.2.5](https://github.com/autonity/autonity-oracle/releases/tag/v0.2.5). The docker image release is: [`ghcr.io/autonity/autonity-oracle:v0.2.5`](https://github.com/orgs/autonity/packages/container/autonity-oracle/480802171?tag=v0.2.5).
 
 ## ATN funding
 
@@ -81,10 +81,10 @@ Mainnet is built using:
 
 DAX is a Uniswap V2 clone AMM. Bridge USDC to Autonity from Polygon Mainnet using the VIA Labs bridge and trade in the DAX to purchase ATN.
 
-<!--
-To bridge see [Use the Bridge](/networks/testnet-mainnet/bridge.md)
+<!-- 
+To bridge see [Use the Bridge](/networks/mainnet/bridge.md)
 
-To trade see [Use the DAX](networks/testnet-mainnet/dax.md)
+To trade see [Use the DAX](/networks/mainnet/dax.md)
 -->
 
 ## Public endpoints

--- a/networks/testnet-bakerloo/index.md
+++ b/networks/testnet-bakerloo/index.md
@@ -42,7 +42,7 @@ The network's genesis configuration is:
 | `config.autonity.minBaseFee`       | `10_000_000_000` (10 GWei)        |
 | `config.autonity.operator`         | `0x83e5e0eab996Bb894814fa8F0AC96a0D314f06F3` |
 | `config.autonity.treasury`         | `0xd735174cf1d0D9150cb57750C45B6e8095160f6A` |
-| `config.autonity.validators`       |  See `Validators` in the AGC [`Bakerloo Config`](https://github.com/autonity/autonity/blob/release/v1.1.1/params/bakerloo_config.go#L163) for details.  |
+| `config.autonity.validators`       |  See `BakerlooValidators` in the AGC [`Bakerloo Config`](https://github.com/autonity/autonity/blob/release/v1.1.1/params/bakerloo_config.go#L163) for details.  |
 | `config.oracle.symbols`       | `['AUD-USD','CAD-USD','EUR-USD','GBP-USD','JPY-USD','SEK-USD']`        |
 | `config.oracle.votePeriod`       | `600` (600  blocks)       |
 

--- a/node-operators/install-aut/index.md
+++ b/node-operators/install-aut/index.md
@@ -136,7 +136,7 @@ The following should be installed in order to build the Autonity Go Client:
 2. Enter the `autonity` directory and ensure you are building from the correct release. This can be done by checking out the Release Tag in a branch:
 
     ```bash
-    git checkout tags/v1.1.1 -b v1.1.1
+    git checkout tags/v1.1.2 -b v1.1.2
     ```
 
 3. Build autonity:
@@ -209,10 +209,10 @@ sudo systemctl restart docker
 1. Pull the Autonity Go Client image from the Github Container Registry:
    
     ```bash
-    docker pull ghcr.io/autonity/autonity:v1.1.1
+    docker pull ghcr.io/autonity/autonity:v1.1.2
     ```
 
-   <!-- (where `latest` can be replaced with a specific version, i.e. `v1.1.1`) -->
+   <!-- (where `latest` can be replaced with a specific version, i.e. `v1.1.2`) -->
 
    ::: {.callout-note title="Note" collapse="false"}
    For more information on using and pulling Docker images from GHCR, see GitHub docs [Working with the container registry](https://docs.github.com/en/packages/working-with-a-github-packages-registry/working-with-the-container-registry).
@@ -235,9 +235,9 @@ $ ./autonity version
 ```
 ```console
 Autonity
-Version: 1.1.1
-Git Commit: b8bee667dcdea6e47dde0361c41d044b360a102e
-Git Commit Date: 20250731
+Version: 1.1.2
+Git Commit: 03bcaa30ef200739a4345042c731fe66974a485d
+Git Commit Date: 20250807
 Architecture: amd64
 Protocol Versions: [66]
 Go Version: go1.24.0
@@ -249,11 +249,11 @@ GOROOT=
 If using Docker, the setup of the image can be verified with:
 
 ```bash
-$ docker run --rm ghcr.io/autonity/autonity:v1.1.1 version
+$ docker run --rm ghcr.io/autonity/autonity:v1.1.2 version
 ```
 ```console
 Autonity
-Version: 1.1.1
+Version: 1.1.2
 Architecture: amd64
 Protocol Versions: [66]
 Go Version: go1.24.5

--- a/oracle/install-oracle/index.md
+++ b/oracle/install-oracle/index.md
@@ -102,8 +102,13 @@ The following should be installed in order to build the Autonity Oracle Server:
 2. Enter the `autonity-oracle` directory and ensure you are building from the correct release. This can be done by checking out the Release Tag in a branch:
 
     ```bash
-    git checkout tags/v0.2.4 -b v0.2.4
+    git checkout tags/v0.2.5 -b v0.2.5
     ```
+    
+::: {.callout-caution title="Connecting to Bakerloo Testnet?" collapse="false"}
+If you are deploying to the Bakerloo Testnet modify the command to use the [release version](/networks/testnet-bakerloo/#release) on Bakerloo.
+:::
+
 3. Build autonity oracle server:
 
     ```bash
@@ -115,12 +120,13 @@ The following should be installed in order to build the Autonity Oracle Server:
 
     <!-- Adjust the `make` command according to the testnet you are connecting to. -->
 
-    If connecting to Bakerloo Testnet, run:
+::: {.callout-caution title="Connecting to Bakerloo Testnet?" collapse="false"}
+If you are deploying to the Bakerloo Testnet modify the command to build for Bakerloo:
     
-    ```bash
-    cd autonity-oracle
-    make autoracle-bakerloo
-    ```
+```bash
+make autoracle-bakerloo
+ ```
+:::
     
 3. (Optional) Add data source plugins. Navigate to the `plugins` sub-directory of your working directory and add sub-directories for additional plugins you are installing. See [Installing data source plugins](/oracle/install-oracle/#install-plugin).
 
@@ -174,23 +180,20 @@ sudo systemctl restart docker
    
       
     ```bash
-    docker pull ghcr.io/autonity/autonity-oracle:v0.2.4
+    docker pull ghcr.io/autonity/autonity-oracle:v0.2.5
     ```
-   
-   If you are deploying to the Bakerloo Testnet:
-   
-    ```bash
-    docker pull ghcr.io/autonity/autonity-oracle-bakerloo:v0.2.4
-    ```
+
+::: {.callout-caution title="Connecting to Bakerloo Testnet?" collapse="false"}
+If you are deploying to the Bakerloo Testnet modify the docker pull command to use the [release version](/networks/testnet-bakerloo/#release) on Bakerloo.
+:::
 
    <!-- (where `latest` can be replaced with another version) -->
 
-   ::: {.callout-note title="Note" collapse="false"}
-   For more information on using and pulling Docker images from GHCR, see GitHub docs [Working with the container registry](https://docs.github.com/en/packages/working-with-a-github-packages-registry/working-with-the-container-registry).
+::: {.callout-note title="Note" collapse="false"}
+For more information on using and pulling Docker images from GHCR, see GitHub docs [Working with the container registry](https://docs.github.com/en/packages/working-with-a-github-packages-registry/working-with-the-container-registry).
    
-   You can view the AOS Docker container images in the Autonity GitHub at <https://github.com/orgs/autonity/packages/container/package/autonity-oracle> and <https://github.com/orgs/autonity/packages/container/package/autonity-oracle-bakerloo>.
-   
-   :::
+You can view the AOS Docker container images in the Autonity GitHub at <https://github.com/orgs/autonity/packages/container/package/autonity-oracle> and <https://github.com/orgs/autonity/packages/container/package/autonity-oracle-bakerloo>.
+:::
 
 3. Verify the authenticity of the Autonity Oracle Server Docker images against the official [image digests](https://github.com/autonity/autonity-oracle/pkgs/container/autonity-oracle/versions):
 
@@ -216,10 +219,22 @@ $ ./build/bin/autoracle version
 ```
 ```console
 version
-v0.2.4
+v0.2.5
 ```
 
-If using Docker, the setup of the Bakerloo Testnet image can be verified with:
+If using Docker:
+
+```bash
+docker run --rm ghcr.io/autonity/autonity-oracle:v0.2.5 version
+```
+```console
+v0.2.5
+```
+
+::: {.callout-caution title="Connecting to Bakerloo Testnet?" collapse="false"}
+If you are deploying to the Bakerloo Testnet modify the docker pull command to use the docker image and [release version](/networks/testnet-bakerloo/#release) on Bakerloo.
+
+The setup of the Bakerloo Testnet image can be verified with:
 
 ```bash
 docker run --rm ghcr.io/autonity/autonity-oracle-bakerloo:v0.2.4 version 
@@ -227,6 +242,7 @@ docker run --rm ghcr.io/autonity/autonity-oracle-bakerloo:v0.2.4 version
 ```console
 v0.2.4
 ```
+:::
 
 ::: {.callout-note title="Note" collapse="false"}
 The output above will vary depending on the version of the Autonity Oracle Server you have installed.  Confirm that the "Version" field is consistent with the version you expect.


### PR DESCRIPTION
Edits updating docs to the v1.1.2 and v0.2.5  Mainnet Release versions in the Networks and install AGC and AOS guides.