### PR TITLE
Update Networks and Install pages for new AOS Version v0.2.6

### DIFF
--- a/networks/mainnet/index.md
+++ b/networks/mainnet/index.md
@@ -73,7 +73,7 @@ Mainnet is built using:
 
 - Autonity Go Client (AGC) Release: [v1.1.2](https://github.com/autonity/autonity/releases/tag/v1.1.2). The docker image release is: [`ghcr.io/autonity/autonity:v1.1.2`](https://github.com/autonity/autonity/pkgs/container/autonity/480778709?tag=v1.1.2).
 
-- Autonity Oracle Server (AOS) Release: [v0.2.5](https://github.com/autonity/autonity-oracle/releases/tag/v0.2.5). The docker image release is: [`ghcr.io/autonity/autonity-oracle:v0.2.5`](https://github.com/orgs/autonity/packages/container/autonity-oracle/480802171?tag=v0.2.5).
+- Autonity Oracle Server (AOS) Release: [v0.2.6](https://github.com/autonity/autonity-oracle/releases/tag/v0.2.6). The docker image release is: [`ghcr.io/autonity/autonity-oracle:v0.2.6`](https://github.com/orgs/autonity/packages/container/autonity-oracle/483926882?tag=v0.2.6).
 
 ## ATN funding
 

--- a/networks/testnet-bakerloo/index.md
+++ b/networks/testnet-bakerloo/index.md
@@ -62,9 +62,9 @@ The network bootnode addresses are:
 
 The current iteration of the Bakerloo network is built using:
 
-- Autonity Go Client (AGC) Release: [v1.1.1](https://github.com/autonity/autonity/releases/tag/v1.1.1). The docker image release is: `ghcr.io/autonity/autonity:v1.1.1`.
+- Autonity Go Client (AGC) Release: [v1.1.1](https://github.com/autonity/autonity/releases/tag/v1.1.1). The docker image release is: [`ghcr.io/autonity/autonity:v1.1.1`](https://github.com/autonity/autonity/pkgs/container/autonity/476121691?tag=v1.1.1).
 
-- Autonity Oracle Server (AOS) Release: [v0.2.4](https://github.com/autonity/autonity-oracle/releases/tag/v0.2.4). The docker image release is: `ghcr.io/autonity/autonity-oracle-bakerloo:v0.2.4`.
+- Autonity Oracle Server (AOS) Release: [v0.2.6](https://github.com/autonity/autonity-oracle/releases/tag/v0.2.6). The docker image release is: [`ghcr.io/autonity/autonity-oracle-bakerloo:v0.2.6`](https://github.com/orgs/autonity/packages/container/autonity-oracle-bakerloo/483918507?tag=v0.2.6).
 
 ## Faucet
 

--- a/oracle/install-oracle/index.md
+++ b/oracle/install-oracle/index.md
@@ -102,7 +102,7 @@ The following should be installed in order to build the Autonity Oracle Server:
 2. Enter the `autonity-oracle` directory and ensure you are building from the correct release. This can be done by checking out the Release Tag in a branch:
 
     ```bash
-    git checkout tags/v0.2.5 -b v0.2.5
+    git checkout tags/v0.2.6 -b v0.2.6
     ```
     
 ::: {.callout-caution title="Connecting to Bakerloo Testnet?" collapse="false"}
@@ -180,7 +180,7 @@ sudo systemctl restart docker
    
       
     ```bash
-    docker pull ghcr.io/autonity/autonity-oracle:v0.2.5
+    docker pull ghcr.io/autonity/autonity-oracle:v0.2.6
     ```
 
 ::: {.callout-caution title="Connecting to Bakerloo Testnet?" collapse="false"}
@@ -219,30 +219,17 @@ $ ./build/bin/autoracle version
 ```
 ```console
 version
-v0.2.5
+v0.2.6
 ```
 
 If using Docker:
 
 ```bash
-docker run --rm ghcr.io/autonity/autonity-oracle:v0.2.5 version
+docker run --rm ghcr.io/autonity/autonity-oracle:v0.2.6 version
 ```
 ```console
-v0.2.5
+v0.2.6
 ```
-
-::: {.callout-caution title="Connecting to Bakerloo Testnet?" collapse="false"}
-If you are deploying to the Bakerloo Testnet modify the docker pull command to use the docker image and [release version](/networks/testnet-bakerloo/#release) on Bakerloo.
-
-The setup of the Bakerloo Testnet image can be verified with:
-
-```bash
-docker run --rm ghcr.io/autonity/autonity-oracle-bakerloo:v0.2.4 version 
-```
-```console
-v0.2.4
-```
-:::
 
 ::: {.callout-note title="Note" collapse="false"}
 The output above will vary depending on the version of the Autonity Oracle Server you have installed.  Confirm that the "Version" field is consistent with the version you expect.


### PR DESCRIPTION
Minor PR to update the docs for the oracle release <https://github.com/autonity/autonity-oracle/releases/tag/v0.2.6>, which is compatible with AGC v1.1.1 on Bakerloo and v1.1.2 on Mainnet:

- Networks: Mainnet and Bakerloo Testnet pages: update AOS Version to v0.2.6
- AOS Install guide: update AOS Version to v0.2.6; remove redundant notebox.



