### PR TITLE
Networks - fix broken link in Network details section

### DIFF
--- a/networks/mainnet/index.md
+++ b/networks/mainnet/index.md
@@ -25,7 +25,11 @@ Mainnet is for participants interested in:
 |Symbol|`ATN`|
 |Block Explorer URL (optional)|`https://autonityscan.org`|
 
-(The above information can be used to connect an existing client such as [MetaMask](https://metamask.zendesk.com/hc/en-us/articles/360043227612-How-to-add-a-custom-network-RPC))
+::: {.callout-tip title="Adding Autonity as a custom network to your wallet" collapse="false"}
+
+The above information can be used to add Autonity as a custom network to to an existing client such as [MetaMask](https://support.metamask.io/configure/networks/how-to-add-a-custom-network-rpc/)).
+
+:::
 
 ## Genesis configuration
 

--- a/networks/testnet-bakerloo/index.md
+++ b/networks/testnet-bakerloo/index.md
@@ -23,7 +23,11 @@ Bakerloo provides a reliable test network for community developers, node operato
 |Symbol|`ATN`|
 |Block Explorer URL (optional)|`https://bakerloo.autonity.org/`|
 
-(The above information can be used to connect an existing client such as [MetaMask](https://metamask.zendesk.com/hc/en-us/articles/360043227612-How-to-add-a-custom-network-RPC))
+::: {.callout-tip title="Adding Autonity as a custom network to your wallet" collapse="false"}
+
+The above information can be used to add Autonity as a custom network to to an existing client such as [MetaMask](https://support.metamask.io/configure/networks/how-to-add-a-custom-network-rpc/)).
+
+:::
 
 ## Genesis configuration
 

--- a/networks/testnet-piccadilly/index.md
+++ b/networks/testnet-piccadilly/index.md
@@ -33,7 +33,11 @@ Piccadilly was for participants interested in:
 |Symbol|`ATN`|
 |Block Explorer URL (optional)|`https://piccadilly.autonity.org/`|
 
-(The above information can be used to connect an existing client such as [MetaMask](https://metamask.zendesk.com/hc/en-us/articles/360043227612-How-to-add-a-custom-network-RPC))
+::: {.callout-tip title="Adding Autonity as a custom network to your wallet" collapse="false"}
+
+The above information can be used to add Autonity as a custom network to to an existing client such as [MetaMask](https://support.metamask.io/configure/networks/how-to-add-a-custom-network-rpc/)).
+
+:::
 
 ## Genesis configuration
 


### PR DESCRIPTION
PR to the Network details in all network pages to:

- fix a broken link in the note on how to connect to an existing wallet client, and,
- move the note into a 'tip' note box.

Replaces:

```
(The above information can be used to connect an existing client such as [MetaMask](https://metamask.zendesk.com/hc/en-us/articles/360043227612-How-to-add-a-custom-network-RPC))
```

With:

```
::: {.callout-tip title="Adding Autonity as a custom network to your wallet" collapse="false"}

The above information can be used to add Autonity as a custom network to to an existing client such as [MetaMask](https://support.metamask.io/configure/networks/how-to-add-a-custom-network-rpc/)).

:::
```