### PR TITLE
fix font rendering

### DIFF
--- a/_theme/theme.scss
+++ b/_theme/theme.scss
@@ -61,7 +61,7 @@ $font-size-root: 0.95rem;
 
 /*-- scss:rules --*/
 body {
-    font-family: proxima nova,sans-serif;
+    font-family: sans-serif;
 }
 
 a {


### PR DESCRIPTION
I noticed that when using Chrome, the body font used throughout the site is extremely thin and very hard to read. This is because the body font-family style defines "proxima nova" as the first entry; on my Ubuntu system, it seems the font of this name is the light version (not regular, which is "Proxima Nova Regular").

Interestingly, this issue does not appear on Firefox (which seems to ignore that entry), and it would not happen on systems where Proxima Nova is not installed.

Having inspected the CSS file, it seems that reference to Proxima Nova is by mistake anyway, since the "Noto Sans" font is included in the CSS, and defined as default for "sans-serif". (Which is indeed what Firefox and systems without Proxima Nova fall back on) -- So, simply removing the "proxima nova" reference entirely returns to expected behaviour.