### PR TITLE
Edits for bootnode specification

### DIFF
--- a/concepts/architecture/index.md
+++ b/concepts/architecture/index.md
@@ -411,5 +411,3 @@ For transaction gossiping between nodes the Ethereum wire protocol is used for P
 For consensus gossiping a separate consensus protocol runs alongside the ethwire protocol for the execution of Autonity's BFT Tendermint Consensus algorithm. This channel is used by committee members to broadcast consensus messages during Tendermint consensus rounds (propose, prevote and precommit). Validator messages sent during consensus rounds are cryptographically signed (sealed). A subset of these signatures are saved in the [block header](/concepts/system-model/#block-header) as cryptographic proof of the validator quorum that agreed on the block: the *proposer seal*, seal of the committee member proposing the block, and the *quorum certificate*, a single aggregated BLS signature of the committee members that voted and agreed on the block.
 
 To learn more about the separation of transaction and consensus gossiping traffic, see [System model, Networking](/concepts/system-model/#networking).
-
-For how bootnode provision works, see the How to [Run Autonity](/node-operators/run-aut/).

--- a/developer/custom-networks/index.md
+++ b/developer/custom-networks/index.md
@@ -6,12 +6,67 @@ draft: false
 ---
 
 To connect your node to a custom Autonity network, you will need the network's:
-  - bootnodes, typically given in a  `static-nodes.json` file or specified when running the node with the `--bootnodes` command-line option.
+
+  - bootnodes, specify statically in a  `static-nodes.json` file or dynamically using the `--bootnodes` command-line option.
   - genesis configuration file,  `genesis.json`.
 
   See [Local Autonity Network configuration](/reference/genesis/#local-autonity-network-configuration) in the [Genesis](/reference/genesis/) reference for how to create these files.
 
-::: {.callout-note title="Note" collapse="false"}
+::: {.callout-tip title="How to identify and configure bootnodes for a custom network" collapse="true"}
+
+A new node must connect to at least one known peer to discover additional peers and begin syncing.
+
+To configure bootnodes for a custom network:
+
+1. **Obtain candidate enode addresses** from one or more of the following sources:
+   - public RPC providers, using `admin_nodeInfo` where enabled,
+   - validator dashboards,
+   - chain state queries,
+   - trusted node operators.
+
+2. **Verify TCP reachability**:
+
+   ```bash
+   nc -vz <ip> 30303
+   ```
+
+   Optionally, verify UDP reachability:
+
+   ```bash
+   nc -vzu <ip> 30303
+   ```
+
+   Nodes with UDP port `30303` open support more complete peer discovery.
+
+3. **Configure one or more reachable peers** using either of the following methods:
+   - add the enode addresses to a `static-nodes.json` file and place it in the chaindata directory, as described in [Setting up custom networks](/developer/custom-networks/),
+   - pass a comma-separated list of enode addresses using the `--bootnodes` option when starting the client.
+
+4. **Start the node**. The node connects to the specified peer and expands its peer table. For best results, use a peer with both TCP and UDP port `30303` open.
+
+### Related resources
+
+- Example static nodes file: [Static nodes file](/reference/genesis/#static-nodes-file)
+- Custom network configuration: [Setting up custom networks](/developer/custom-networks/)
+- Commands for retrieving node addresses and enodes using [Autonity CLI](/account-holders/setup-aut/):
+  - `aut validator list`
+  - `aut protocol committee-enodes`
+  - `aut node info`
+- Community validator explorer dashboards: [awesome-autonity](https://github.com/autonity/awesome-autonity?tab=readme-ov-file#explorers)
+- Autonity [Discord Server](https://discord.gg/autonity): *Validators* and *Technical Help* channels.
+
+### Example
+
+```bash
+nc -vzu 125.181.215.22 30303
+Connection to 125.181.215.22 port 30303 [udp/*] succeeded!
+
+nc -vz 125.181.215.22 30303
+Connection to 125.181.215.22 port 30303 [tcp/*] succeeded!
+```
+:::
+
+::: {.callout-caution title="Caution" collapse="false"}
 Note that the client provides a [command-line option](/reference/cli/agc/#command-line-options) for connecting to the Autonity Bakerloo Testnet `--bakerloo`. The node will not run if you specify both genesis and bootnodes for a custom network **and** a testnet flag. The client will create a genesis block for the custom network's genesis configuration and the node's local store will then have an incompatible genesis with the testnet.
 :::
 

--- a/networks/mainnet/index.md
+++ b/networks/mainnet/index.md
@@ -53,16 +53,9 @@ The network's genesis configuration is:
 | `config.oracle.votePeriod`         | `600` (600  blocks)          |
 
 
-## Bootnodes
+## Node discovery
 
-The network bootnode addresses are:
-
-| enode | region |
-| :-- | :--      |
-| `enode://bba73a4252e64fa23e11bcfc9c0c03e912fc8c17374a637bbc9cb42351a22624f463b0e774a0ab06141690d4499f686e2446fc96cb76fd7c842a191bce047f8a@34.147.142.153:30303` | europe-west2 |
-| `enode://87dd0697db1a6a434cdc1813b45396a8aa2003ca65a9cbb7d8fc82e5fb608b561af012a91aef827979ffa973ddb0df7c7dc43e0778729cd067d91554b1138413@35.200.148.179:30303` | asia-south1b|
-| `enode://d295a022386c51f52b7630586304eac18fc2a299276fcea31771ec0c20bf967e772d90467f18d6b7fe3e7dfbcfd896db2192a3e9556eecbfdae43eab6c097ee0@34.102.61.248:30303` | us-west2 |
-
+Bootnode addresses must be specified explicitly for peer node discovery when joining and syncing with the network. For configuration details, see the Development guide page [Setting up custom networks](/developer/custom-networks/) and **How to identify and configure bootnodes for a custom network**.
 
 ## Release
 

--- a/networks/testnet-bakerloo/index.md
+++ b/networks/testnet-bakerloo/index.md
@@ -52,16 +52,9 @@ The network's genesis configuration is:
 | `config.oracle.votePeriod`       | `600` (600  blocks)       |
 
 
-## Bootnodes
+## Node discovery
 
-The network bootnode addresses are:
-
-| enode | region |
-| :-- | :--      |
-| `enode://aa56696a131d2cfac1cfaa18dba06f5dc32ef57cf8c8b3548ab1f74227987c5656c2c0eecba61dfdd0754030c23d433e4db554f6b677eb900c05b98792b1d7fb@34.39.58.139:30303` | europe-west2 |
-| `enode://feb31d821a92db0c7a6260c1eff9539bde1db5d947f319b7f761ea99479b5b31a95209153c9c910c8f94e8f557541a7ffa72a4a1ff0602944df2b0e6611be4ce@35.200.221.60:30303` | asia-south1 |
-| `enode://b6e18b34019e70d32bfd43bcf66b71a127117f3402c29f857337b9dd3ccc45c4a9d441d211ca2a201bd46d003cfbf84a2b0721cf9b939ae6abd66dfe698700fc@35.235.121.67:30303` | us-west2 |
-
+Bootnode addresses must be specified explicitly for peer node discovery when joining and syncing with the network. For configuration details, see the Development guide page [Setting up custom networks](/developer/custom-networks/) and **How to identify and configure bootnodes for a custom network**.
 
 ## Release
 

--- a/node-operators/run-aut/index.md
+++ b/node-operators/run-aut/index.md
@@ -13,9 +13,9 @@ description: >
 
 When initialised Autonity Go Client will connect to the specified Autonity network, find peer nodes, and begin to sync. AGC's default setting is to connect to Mainnet.
 
-If connecting to the [Bakerloo Testnet](/networks/testnet-bakerloo/), then the `--bakerloo` command-line option is specified when running the node. The Mainnet and Bakerloo genesis configuration are specified along with bootnodes in the AGC configuration and do not need to be specified.
+If connecting to a public Autonity network, the genesis configuration is loaded automatically. However, bootnode addresses must be specified explicitly for peer discovery. For configuration details, see the Development guide page [Setting up custom networks](https://docs.autonity.org/developer/custom-networks/) and **How to identify and configure bootnodes for a custom network**.
 
-If connecting to a custom network genesis configuration and bootnode addresses will need to be specified. For how to do this see the Development guide page [Setting up custom networks](https://docs.autonity.org/developer/custom-networks/).
+If connecting to a custom network genesis configuration and bootnode addresses must be specified. For how to do this see the Development guide page [Setting up custom networks](https://docs.autonity.org/developer/custom-networks/).
 
 This guide exemplifies connecting to Bakerloo. If connecting to Mainnet simply remove the `--bakerloo` flag.
 
@@ -33,7 +33,9 @@ To connect to a network and sync, get the genesis and bootnode files if needed, 
     mkdir autonity-chaindata
     ```
 
-3. Start autonity:
+3. Specify bootnodes - see guide page [Setting up custom networks](/developer/custom-networks/) and **How to identify and configure bootnodes for a custom network**.
+
+4. Start autonity:
 
     ``` bash
     autonity \
@@ -82,7 +84,9 @@ Autonity will download the blockchain in "snap" syncmode by default.  Once fully
 	```bash
     mkdir autonity-chaindata
     ```
-3. Start the node. Set the Docker configuration and the arguments for connecting Autonity to a network.
+3. Specify bootnodes - see guide page [Setting up custom networks](/developer/custom-networks/) and **How to identify and configure bootnodes for a custom network**.
+
+4. Start the node. Set the Docker configuration and the arguments for connecting Autonity to a network.
 
    ```bash
    docker run \


### PR DESCRIPTION
PR for issue #283 Clarify bootnode provision in docs. PR makes edits to:

- Guide, Run Autonity:

  - Page: https://docs.autonity.org/node-operators/run-aut/#running-the-autonity-go-client 
  - Edits to state bootnodes need to be specified for connecting to public and custom networks, hyperlinking to notebox instructions detailing "How to identify and configure bootnodes for a custom network" in the development guide "Setting up custom networks".
    
-  Guide, Development, Setting up custom networks
 
   -  Page: https://docs.autonity.org/developer/custom-networks/
   -  Edits to describe bootnode specification and add instructions on how to identify and specify bootnodes from publicly accessible network nodes this in a notebox "How to identify and configure bootnodes for a custom network".

-  Networks, Bakerloo and Mainnet pages
   -  Pages: https://docs.autonity.org/networks/mainnet/#bootnodes, https://docs.autonity.org/networks/testnet-bakerloo/#bootnodes
   -  Replaced the 'Bootnodes' section with a 'Node discovery' section. States bootnodes must be specified and hyperlinks to notebox "How to identify and configure bootnodes for a custom network." in the development guide "Setting up custom networks".

- Concept, Architecture.
  - Page: https://docs.autonity.org/concepts/architecture/#communication-layer
   - Remove unnecessary sentence mentioning bootnode provision end of page.